### PR TITLE
Add "pip" to the python:2 image since it isn't included upstream

### DIFF
--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -17,4 +17,7 @@ RUN ./configure \
 	&& make install \
 	&& make clean
 
+# install "pip", since the vast majority of users of this image will want it
+RUN curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python2
+
 CMD ["python2"]


### PR DESCRIPTION
Fixes #1
