### PR TITLE
Add language environmental variables

### DIFF
--- a/3/Dockerfile
+++ b/3/Dockerfile
@@ -25,4 +25,6 @@ RUN cd /usr/local/bin \
 	&& ln -s python3 python \
 	&& ln -s python-config3 python-config
 
+ENV LANG C.UTF-8
+
 CMD ["python3"]


### PR DESCRIPTION
If I do not set these variables, I get various unicode errors. Including when I try to do `pip install -e .` in my Dockerfile.

```
 ---> cb8d462c9cc4
Step 1 : ADD . /code/
 ---> 0c1373951289
Removing intermediate container f36f575d2409
Step 2 : WORKDIR /code
 ---> Running in 46417f28378e
 ---> cfcedd28f14e
Removing intermediate container 46417f28378e
Step 3 : RUN pip install -r requirements-testing.txt -e .
 ---> Running in 4608c7f74625
Obtaining file:///code
  Running setup.py (path:/code/setup.py) egg_info for package from file:///code
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/code/setup.py", line 21, in <module>
        long_description=open('README.md').read(),
      File "/usr/local/lib/python3.4/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 9342: ordinal not in range(128)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/code/setup.py", line 21, in <module>

    long_description=open('README.md').read(),

  File "/usr/local/lib/python3.4/encodings/ascii.py", line 26, in decode

    return codecs.ascii_decode(input, self.errors)[0]

UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 9342: ordinal not in range(128)

----------------------------------------
Cleaning up...
Command python setup.py egg_info failed with error code 1 in /code
Storing debug log for failure in /.pip/pip.log
Service 'python' failed to build: The command [/bin/sh -c pip install -r requirements-testing.txt -e .] returned a non-zero code: 1
```
