### PR TITLE
Add pip to python3.3

### DIFF
--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -25,7 +25,6 @@ RUN ./configure \
 RUN cd /usr/local/bin \
 	&& ln -s easy_install-3.4 easy_install \
 	&& ln -s idle3 idle \
-	&& ln -s pip3 pip \
 	&& ln -s pydoc3 pydoc \
 	&& ln -s python3 python \
 	&& ln -s python-config3 python-config


### PR DESCRIPTION
Pip was missing from python 3.3 image, there was only invalid symlink to pip3. It should work now.
