### PR TITLE
Add slim deps of libsqlite3-0 at runtime and libsqlite3-dev at build time

### DIFF
--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -9,8 +9,8 @@ ENV LANG C.UTF-8
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
+		libsqlite3-0 \
 		libssl1.0.0 \
-		sqlite3 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PYTHON_VERSION 2.7.8

--- a/3.3/slim/Dockerfile
+++ b/3.3/slim/Dockerfile
@@ -9,8 +9,8 @@ ENV LANG C.UTF-8
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
+		libsqlite3-0 \
 		libssl1.0.0 \
-		sqlite3 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PYTHON_VERSION 3.3.6

--- a/3.4/slim/Dockerfile
+++ b/3.4/slim/Dockerfile
@@ -9,8 +9,8 @@ ENV LANG C.UTF-8
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
+		libsqlite3-0 \
 		libssl1.0.0 \
-		sqlite3 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PYTHON_VERSION 3.4.2


### PR DESCRIPTION
Tested successfully using: (across both the non-slim and the slim variants of each of 2.7, 3.3, and 3.4)

``` bash
docker run -it --rm image-being-tested bash -xec '
    # ...
    python -c "import sqlite3; print(sqlite3.sqlite_version); con = sqlite3.connect(\":memory:\", 1, sqlite3.PARSE_DECLTYPES, None); cur = con.cursor(); cur.execute(\"CREATE TABLE test (id INT, txt TEXT)\"); cur.execute(\"INSERT INTO test VALUES (?, ?)\", (42, \"wut\")); cur.execute(\"SELECT * FROM test\"); assert(cur.fetchall() == [(42, \"wut\")]); cur.execute(\"DROP TABLE test\"); con.close()"
    # ...
'
```

``` python
import sqlite3
print(sqlite3.sqlite_version)
con = sqlite3.connect(":memory:", 1, sqlite3.PARSE_DECLTYPES, None)
cur = con.cursor()
cur.execute("CREATE TABLE test (id INT, txt TEXT)")
cur.execute("INSERT INTO test VALUES (?, ?)", (42, "wut"))
cur.execute("SELECT * FROM test")
assert(cur.fetchall() == [(42, "wut")])
cur.execute("DROP TABLE test")
con.close()
```

Fixes #25
