### PR TITLE
Add GPG verification to slim and wheezy variants too

### DIFF
--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -15,12 +15,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV PYTHON_VERSION 2.7.9
 
+# gpg: key 18ADD4FF: public key "Benjamin Peterson <benjamin@python.org>" imported
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
+
 RUN set -x \
 	&& buildDeps='curl gcc libc6-dev libsqlite3-dev libssl-dev make xz-utils zlib1g-dev' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/python \
-	&& curl -SL "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz" \
-		| tar -xJC /usr/src/python --strip-components=1 \
+	&& curl -SL "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz" -o python.tar.xz \
+	&& curl -SL "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz.asc" -o python.tar.xz.asc \
+	&& gpg --verify python.tar.xz.asc \
+	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
+	&& rm python.tar.xz* \
 	&& cd /usr/src/python \
 	&& ./configure --enable-shared \
 	&& make -j$(nproc) \

--- a/2.7/wheezy/Dockerfile
+++ b/2.7/wheezy/Dockerfile
@@ -7,12 +7,18 @@ RUN apt-get purge -y python.*
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-ENV PYTHON_VERSION 2.7.8
+ENV PYTHON_VERSION 2.7.9
+
+# gpg: key 18ADD4FF: public key "Benjamin Peterson <benjamin@python.org>" imported
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 
 RUN set -x \
 	&& mkdir -p /usr/src/python \
-	&& curl -SL "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz" \
-		| tar -xJC /usr/src/python --strip-components=1 \
+	&& curl -SL "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz" -o python.tar.xz \
+	&& curl -SL "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz.asc" -o python.tar.xz.asc \
+	&& gpg --verify python.tar.xz.asc \
+	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
+	&& rm python.tar.xz* \
 	&& cd /usr/src/python \
 	&& ./configure --enable-shared \
 	&& make -j$(nproc) \

--- a/3.3/slim/Dockerfile
+++ b/3.3/slim/Dockerfile
@@ -15,12 +15,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV PYTHON_VERSION 3.3.6
 
+# gpg: key 36580288: public key "Georg Brandl (Python release signing key) <georg@python.org>" imported
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 26DEA9D4613391EF3E25C9FF0A5B101836580288
+
 RUN set -x \
 	&& buildDeps='curl gcc libc6-dev libsqlite3-dev libssl-dev make xz-utils zlib1g-dev' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/python \
-	&& curl -SL "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz" \
-		| tar -xJC /usr/src/python --strip-components=1 \
+	&& curl -SL "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz" -o python.tar.xz \
+	&& curl -SL "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz.asc" -o python.tar.xz.asc \
+	&& gpg --verify python.tar.xz.asc \
+	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
+	&& rm python.tar.xz* \
 	&& cd /usr/src/python \
 	&& ./configure --enable-shared \
 	&& make -j$(nproc) \

--- a/3.3/wheezy/Dockerfile
+++ b/3.3/wheezy/Dockerfile
@@ -9,10 +9,16 @@ ENV LANG C.UTF-8
 
 ENV PYTHON_VERSION 3.3.6
 
+# gpg: key 36580288: public key "Georg Brandl (Python release signing key) <georg@python.org>" imported
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 26DEA9D4613391EF3E25C9FF0A5B101836580288
+
 RUN set -x \
 	&& mkdir -p /usr/src/python \
-	&& curl -SL "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz" \
-		| tar -xJC /usr/src/python --strip-components=1 \
+	&& curl -SL "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz" -o python.tar.xz \
+	&& curl -SL "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz.asc" -o python.tar.xz.asc \
+	&& gpg --verify python.tar.xz.asc \
+	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
+	&& rm python.tar.xz* \
 	&& cd /usr/src/python \
 	&& ./configure --enable-shared \
 	&& make -j$(nproc) \

--- a/3.4/slim/Dockerfile
+++ b/3.4/slim/Dockerfile
@@ -15,12 +15,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV PYTHON_VERSION 3.4.2
 
+# gpg: key F73C700D: public key "Larry Hastings <larry@hastings.org>" imported
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
+
 RUN set -x \
 	&& buildDeps='curl gcc libc6-dev libsqlite3-dev libssl-dev make xz-utils zlib1g-dev' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/python \
-	&& curl -SL "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz" \
-		| tar -xJC /usr/src/python --strip-components=1 \
+	&& curl -SL "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz" -o python.tar.xz \
+	&& curl -SL "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz.asc" -o python.tar.xz.asc \
+	&& gpg --verify python.tar.xz.asc \
+	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
+	&& rm python.tar.xz* \
 	&& cd /usr/src/python \
 	&& ./configure --enable-shared \
 	&& make -j$(nproc) \

--- a/3.4/wheezy/Dockerfile
+++ b/3.4/wheezy/Dockerfile
@@ -9,10 +9,16 @@ ENV LANG C.UTF-8
 
 ENV PYTHON_VERSION 3.4.2
 
+# gpg: key F73C700D: public key "Larry Hastings <larry@hastings.org>" imported
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
+
 RUN set -x \
 	&& mkdir -p /usr/src/python \
-	&& curl -SL "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz" \
-		| tar -xJC /usr/src/python --strip-components=1 \
+	&& curl -SL "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz" -o python.tar.xz \
+	&& curl -SL "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz.asc" -o python.tar.xz.asc \
+	&& gpg --verify python.tar.xz.asc \
+	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
+	&& rm python.tar.xz* \
 	&& cd /usr/src/python \
 	&& ./configure --enable-shared \
 	&& make -j$(nproc) \

--- a/update.sh
+++ b/update.sh
@@ -15,7 +15,7 @@ for version in "${versions[@]}"; do
 	fullVersion="$(curl -sSL 'https://www.python.org/downloads/' | awk -F 'Python |</a>' '/<span class="release-number"><a[^>]+>Python '"$version"'./ { print $2 }' | sort -V | tail -1)"
 	(
 		set -x
-		sed -ri 's/^(ENV PYTHON_VERSION) .*/\1 '"$fullVersion"'/' "$version/Dockerfile" "$version/slim/Dockerfile"
+		sed -ri 's/^(ENV PYTHON_VERSION) .*/\1 '"$fullVersion"'/' "$version"/{,slim/,wheezy/}Dockerfile
 		sed -ri 's/^(FROM python):.*/\1:'"$fullVersion"'/' "$version/onbuild/Dockerfile"
 	)
 done


### PR DESCRIPTION
Also, fix `update.sh` to actually hit both the slim and wheezy variants when bumping...

This is the bits that were missed in #34.