### PR TITLE
Configure Python with --enable-unicode=ucs4

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -20,7 +20,7 @@ RUN set -x \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz* \
 	&& cd /usr/src/python \
-	&& ./configure --enable-shared \
+	&& ./configure --enable-shared --enable-unicode=ucs4 \
 	&& make -j$(nproc) \
 	&& make install \
 	&& ldconfig \

--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -28,7 +28,7 @@ RUN set -x \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz* \
 	&& cd /usr/src/python \
-	&& ./configure --enable-shared \
+	&& ./configure --enable-shared --enable-unicode=ucs4 \
 	&& make -j$(nproc) \
 	&& make install \
 	&& ldconfig \

--- a/2.7/wheezy/Dockerfile
+++ b/2.7/wheezy/Dockerfile
@@ -20,7 +20,7 @@ RUN set -x \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz* \
 	&& cd /usr/src/python \
-	&& ./configure --enable-shared \
+	&& ./configure --enable-shared --enable-unicode=ucs4 \
 	&& make -j$(nproc) \
 	&& make install \
 	&& ldconfig \

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -20,7 +20,7 @@ RUN set -x \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz* \
 	&& cd /usr/src/python \
-	&& ./configure --enable-shared \
+	&& ./configure --enable-shared --enable-unicode=ucs4 \
 	&& make -j$(nproc) \
 	&& make install \
 	&& ldconfig \

--- a/3.3/slim/Dockerfile
+++ b/3.3/slim/Dockerfile
@@ -28,7 +28,7 @@ RUN set -x \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz* \
 	&& cd /usr/src/python \
-	&& ./configure --enable-shared \
+	&& ./configure --enable-shared --enable-unicode=ucs4 \
 	&& make -j$(nproc) \
 	&& make install \
 	&& ldconfig \

--- a/3.3/wheezy/Dockerfile
+++ b/3.3/wheezy/Dockerfile
@@ -20,7 +20,7 @@ RUN set -x \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz* \
 	&& cd /usr/src/python \
-	&& ./configure --enable-shared \
+	&& ./configure --enable-shared --enable-unicode=ucs4 \
 	&& make -j$(nproc) \
 	&& make install \
 	&& ldconfig \

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -20,7 +20,7 @@ RUN set -x \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz* \
 	&& cd /usr/src/python \
-	&& ./configure --enable-shared \
+	&& ./configure --enable-shared --enable-unicode=ucs4 \
 	&& make -j$(nproc) \
 	&& make install \
 	&& ldconfig \

--- a/3.4/slim/Dockerfile
+++ b/3.4/slim/Dockerfile
@@ -28,7 +28,7 @@ RUN set -x \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz* \
 	&& cd /usr/src/python \
-	&& ./configure --enable-shared \
+	&& ./configure --enable-shared --enable-unicode=ucs4 \
 	&& make -j$(nproc) \
 	&& make install \
 	&& ldconfig \

--- a/3.4/wheezy/Dockerfile
+++ b/3.4/wheezy/Dockerfile
@@ -20,7 +20,7 @@ RUN set -x \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz* \
 	&& cd /usr/src/python \
-	&& ./configure --enable-shared \
+	&& ./configure --enable-shared --enable-unicode=ucs4 \
 	&& make -j$(nproc) \
 	&& make install \
 	&& ldconfig \


### PR DESCRIPTION
Ref. #21 I went ahead and added the `--enable-unicode=ucs4` configuration flag.

Maybe this could be solved via a `PYTHON_CONFIGURE_OPTS` environment variable?