### PR TITLE
More resilient gpg getting

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -10,7 +10,7 @@ ENV LANG C.UTF-8
 ENV PYTHON_VERSION 2.7.9
 
 # gpg: key 18ADD4FF: public key "Benjamin Peterson <benjamin@python.org>" imported
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 
 RUN set -x \
 	&& mkdir -p /usr/src/python \

--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV PYTHON_VERSION 2.7.9
 
 # gpg: key 18ADD4FF: public key "Benjamin Peterson <benjamin@python.org>" imported
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 
 RUN set -x \
 	&& buildDeps='curl gcc libbz2-dev libc6-dev libsqlite3-dev libssl-dev make xz-utils zlib1g-dev' \

--- a/2.7/wheezy/Dockerfile
+++ b/2.7/wheezy/Dockerfile
@@ -10,7 +10,7 @@ ENV LANG C.UTF-8
 ENV PYTHON_VERSION 2.7.9
 
 # gpg: key 18ADD4FF: public key "Benjamin Peterson <benjamin@python.org>" imported
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 
 RUN set -x \
 	&& mkdir -p /usr/src/python \

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -10,7 +10,7 @@ ENV LANG C.UTF-8
 ENV PYTHON_VERSION 3.3.6
 
 # gpg: key 36580288: public key "Georg Brandl (Python release signing key) <georg@python.org>" imported
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 26DEA9D4613391EF3E25C9FF0A5B101836580288
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 26DEA9D4613391EF3E25C9FF0A5B101836580288
 
 RUN set -x \
 	&& mkdir -p /usr/src/python \

--- a/3.3/slim/Dockerfile
+++ b/3.3/slim/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV PYTHON_VERSION 3.3.6
 
 # gpg: key 36580288: public key "Georg Brandl (Python release signing key) <georg@python.org>" imported
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 26DEA9D4613391EF3E25C9FF0A5B101836580288
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 26DEA9D4613391EF3E25C9FF0A5B101836580288
 
 RUN set -x \
 	&& buildDeps='curl gcc libbz2-dev libc6-dev libsqlite3-dev libssl-dev make xz-utils zlib1g-dev' \

--- a/3.3/wheezy/Dockerfile
+++ b/3.3/wheezy/Dockerfile
@@ -10,7 +10,7 @@ ENV LANG C.UTF-8
 ENV PYTHON_VERSION 3.3.6
 
 # gpg: key 36580288: public key "Georg Brandl (Python release signing key) <georg@python.org>" imported
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 26DEA9D4613391EF3E25C9FF0A5B101836580288
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 26DEA9D4613391EF3E25C9FF0A5B101836580288
 
 RUN set -x \
 	&& mkdir -p /usr/src/python \

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -10,7 +10,7 @@ ENV LANG C.UTF-8
 ENV PYTHON_VERSION 3.4.3
 
 # gpg: key F73C700D: public key "Larry Hastings <larry@hastings.org>" imported
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 
 RUN set -x \
 	&& mkdir -p /usr/src/python \

--- a/3.4/slim/Dockerfile
+++ b/3.4/slim/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV PYTHON_VERSION 3.4.3
 
 # gpg: key F73C700D: public key "Larry Hastings <larry@hastings.org>" imported
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 
 RUN set -x \
 	&& buildDeps='curl gcc libbz2-dev libc6-dev libsqlite3-dev libssl-dev make xz-utils zlib1g-dev' \

--- a/3.4/wheezy/Dockerfile
+++ b/3.4/wheezy/Dockerfile
@@ -10,7 +10,7 @@ ENV LANG C.UTF-8
 ENV PYTHON_VERSION 3.4.3
 
 # gpg: key F73C700D: public key "Larry Hastings <larry@hastings.org>" imported
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 
 RUN set -x \
 	&& mkdir -p /usr/src/python \


### PR DESCRIPTION
- move to "high-availability" [subset](https://sks-keyservers.net/overview-of-pools.php#pool_ha).

related: https://github.com/docker-library/php/pull/92