### PR TITLE
Run update.sh: pip bump 7.0.0

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -13,7 +13,7 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys C01E1CAD5EA2C4F0B8E35
 ENV PYTHON_VERSION 2.7.9
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 6.1.1
+ENV PYTHON_PIP_VERSION 7.0.0
 
 RUN set -x \
 	&& mkdir -p /usr/src/python \

--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -19,7 +19,7 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys C01E1CAD5EA2C4F0B8E35
 ENV PYTHON_VERSION 2.7.9
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 6.1.1
+ENV PYTHON_PIP_VERSION 7.0.0
 
 RUN set -x \
 	&& buildDeps='curl gcc libbz2-dev libc6-dev libsqlite3-dev libssl-dev make xz-utils zlib1g-dev' \

--- a/2.7/wheezy/Dockerfile
+++ b/2.7/wheezy/Dockerfile
@@ -13,7 +13,7 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys C01E1CAD5EA2C4F0B8E35
 ENV PYTHON_VERSION 2.7.9
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 6.1.1
+ENV PYTHON_PIP_VERSION 7.0.0
 
 RUN set -x \
 	&& mkdir -p /usr/src/python \

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -13,7 +13,7 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 26DEA9D4613391EF3E25C
 ENV PYTHON_VERSION 3.3.6
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 6.1.1
+ENV PYTHON_PIP_VERSION 7.0.0
 
 RUN set -x \
 	&& mkdir -p /usr/src/python \

--- a/3.3/slim/Dockerfile
+++ b/3.3/slim/Dockerfile
@@ -19,7 +19,7 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 26DEA9D4613391EF3E25C
 ENV PYTHON_VERSION 3.3.6
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 6.1.1
+ENV PYTHON_PIP_VERSION 7.0.0
 
 RUN set -x \
 	&& buildDeps='curl gcc libbz2-dev libc6-dev libsqlite3-dev libssl-dev make xz-utils zlib1g-dev' \

--- a/3.3/wheezy/Dockerfile
+++ b/3.3/wheezy/Dockerfile
@@ -13,7 +13,7 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 26DEA9D4613391EF3E25C
 ENV PYTHON_VERSION 3.3.6
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 6.1.1
+ENV PYTHON_PIP_VERSION 7.0.0
 
 RUN set -x \
 	&& mkdir -p /usr/src/python \

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -13,7 +13,7 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 97FC712E4C024BBEA48A6
 ENV PYTHON_VERSION 3.4.3
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 6.1.1
+ENV PYTHON_PIP_VERSION 7.0.0
 
 RUN set -x \
 	&& mkdir -p /usr/src/python \

--- a/3.4/slim/Dockerfile
+++ b/3.4/slim/Dockerfile
@@ -19,7 +19,7 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 97FC712E4C024BBEA48A6
 ENV PYTHON_VERSION 3.4.3
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 6.1.1
+ENV PYTHON_PIP_VERSION 7.0.0
 
 RUN set -x \
 	&& buildDeps='curl gcc libbz2-dev libc6-dev libsqlite3-dev libssl-dev make xz-utils zlib1g-dev' \

--- a/3.4/wheezy/Dockerfile
+++ b/3.4/wheezy/Dockerfile
@@ -13,7 +13,7 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 97FC712E4C024BBEA48A6
 ENV PYTHON_VERSION 3.4.3
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 6.1.1
+ENV PYTHON_PIP_VERSION 7.0.0
 
 RUN set -x \
 	&& mkdir -p /usr/src/python \


### PR DESCRIPTION
Making this bump a PR to ensure people see that pip `7.0.0` has backward incompatible changes. See  the `7.0.0 (2015-05-21)` section in the [release notes](https://pip.pypa.io/en/stable/news.html#release-notes).