### PR TITLE
Fix find so tests get removed correctly

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -29,10 +29,11 @@ RUN set -x \
 	&& ldconfig \
 	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python2 \
 	&& pip install --upgrade pip==$PYTHON_PIP_VERSION \
-	&& find /usr/local \
-		\( -type d -a -name test -o -name tests \) \
-		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-		-exec rm -rf '{}' + \
+	&& find /usr/local \( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -prune -exec rm -rf '{}' + \
 	&& rm -rf /usr/src/python
 
 # install "virtualenv", since the vast majority of users of this image will want it

--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -37,10 +37,11 @@ RUN set -x \
 	&& ldconfig \
 	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python2 \
 	&& pip install --upgrade pip==$PYTHON_PIP_VERSION \
-	&& find /usr/local \
-		\( -type d -a -name test -o -name tests \) \
-		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-		-exec rm -rf '{}' + \
+	&& find /usr/local \( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -prune -exec rm -rf '{}' + \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& rm -rf /usr/src/python
 

--- a/2.7/wheezy/Dockerfile
+++ b/2.7/wheezy/Dockerfile
@@ -29,10 +29,11 @@ RUN set -x \
 	&& ldconfig \
 	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python2 \
 	&& pip install --upgrade pip==$PYTHON_PIP_VERSION \
-	&& find /usr/local \
-		\( -type d -a -name test -o -name tests \) \
-		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-		-exec rm -rf '{}' + \
+	&& find /usr/local \( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -prune -exec rm -rf '{}' + \
 	&& rm -rf /usr/src/python
 
 # install "virtualenv", since the vast majority of users of this image will want it

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -29,10 +29,11 @@ RUN set -x \
 	&& ldconfig \
 	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python3 \
 	&& pip install --upgrade pip==$PYTHON_PIP_VERSION \
-	&& find /usr/local \
-		\( -type d -a -name test -o -name tests \) \
-		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-		-exec rm -rf '{}' + \
+	&& find /usr/local \( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -prune -exec rm -rf '{}' + \
 	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist

--- a/3.2/slim/Dockerfile
+++ b/3.2/slim/Dockerfile
@@ -37,10 +37,11 @@ RUN set -x \
 	&& ldconfig \
 	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python3 \
 	&& pip install --upgrade pip==$PYTHON_PIP_VERSION \
-	&& find /usr/local \
-		\( -type d -a -name test -o -name tests \) \
-		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-		-exec rm -rf '{}' + \
+	&& find /usr/local \( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -prune -exec rm -rf '{}' + \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& rm -rf /usr/src/python
 

--- a/3.2/wheezy/Dockerfile
+++ b/3.2/wheezy/Dockerfile
@@ -29,10 +29,11 @@ RUN set -x \
 	&& ldconfig \
 	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python3 \
 	&& pip install --upgrade pip==$PYTHON_PIP_VERSION \
-	&& find /usr/local \
-		\( -type d -a -name test -o -name tests \) \
-		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-		-exec rm -rf '{}' + \
+	&& find /usr/local \( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -prune -exec rm -rf '{}' + \
 	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -29,10 +29,11 @@ RUN set -x \
 	&& ldconfig \
 	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python3 \
 	&& pip install --upgrade pip==$PYTHON_PIP_VERSION \
-	&& find /usr/local \
-		\( -type d -a -name test -o -name tests \) \
-		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-		-exec rm -rf '{}' + \
+	&& find /usr/local \( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -prune -exec rm -rf '{}' + \
 	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist

--- a/3.3/slim/Dockerfile
+++ b/3.3/slim/Dockerfile
@@ -37,10 +37,11 @@ RUN set -x \
 	&& ldconfig \
 	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python3 \
 	&& pip install --upgrade pip==$PYTHON_PIP_VERSION \
-	&& find /usr/local \
-		\( -type d -a -name test -o -name tests \) \
-		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-		-exec rm -rf '{}' + \
+	&& find /usr/local \( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -prune -exec rm -rf '{}' + \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& rm -rf /usr/src/python
 

--- a/3.3/wheezy/Dockerfile
+++ b/3.3/wheezy/Dockerfile
@@ -29,10 +29,11 @@ RUN set -x \
 	&& ldconfig \
 	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python3 \
 	&& pip install --upgrade pip==$PYTHON_PIP_VERSION \
-	&& find /usr/local \
-		\( -type d -a -name test -o -name tests \) \
-		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-		-exec rm -rf '{}' + \
+	&& find /usr/local \( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -prune -exec rm -rf '{}' + \
 	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -28,10 +28,11 @@ RUN set -x \
 	&& make install \
 	&& ldconfig \
 	&& pip3 install --upgrade pip==$PYTHON_PIP_VERSION \
-	&& find /usr/local \
-		\( -type d -a -name test -o -name tests \) \
-		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-		-exec rm -rf '{}' + \
+	&& find /usr/local \( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -prune -exec rm -rf '{}' + \
 	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist

--- a/3.4/slim/Dockerfile
+++ b/3.4/slim/Dockerfile
@@ -36,10 +36,11 @@ RUN set -x \
 	&& make install \
 	&& ldconfig \
 	&& pip3 install --upgrade pip==$PYTHON_PIP_VERSION \
-	&& find /usr/local \
-		\( -type d -a -name test -o -name tests \) \
-		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-		-exec rm -rf '{}' + \
+	&& find /usr/local \( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -prune -exec rm -rf '{}' + \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& rm -rf /usr/src/python
 

--- a/3.4/wheezy/Dockerfile
+++ b/3.4/wheezy/Dockerfile
@@ -28,10 +28,11 @@ RUN set -x \
 	&& make install \
 	&& ldconfig \
 	&& pip3 install --upgrade pip==$PYTHON_PIP_VERSION \
-	&& find /usr/local \
-		\( -type d -a -name test -o -name tests \) \
-		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-		-exec rm -rf '{}' + \
+	&& find /usr/local \( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -prune -exec rm -rf '{}' + \
 	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist


### PR DESCRIPTION
At the moment only the `.py[co]` are getting removed. `find` needs more brackets to correctly do the `exec` on all the results.

```
$ docker run -it python:latest find /usr/local -type d -a -name test -o -name tests
/usr/local/lib/python3.4/tkinter/test
/usr/local/lib/python3.4/ctypes/test
/usr/local/lib/python3.4/lib2to3/tests
/usr/local/lib/python3.4/unittest/test
/usr/local/lib/python3.4/test
/usr/local/lib/python3.4/distutils/tests
/usr/local/lib/python3.4/sqlite3/test
/usr/local/lib/python3.4/site-packages/setuptools/tests
/usr/local/lib/python3.4/site-packages/pkg_resources/tests
/usr/local/lib/python3.4/site-packages/pip/_vendor/pkg_resources/tests
```