### PR TITLE
Skip pip's default caching behavior

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -28,7 +28,7 @@ RUN set -x \
 	&& make install \
 	&& ldconfig \
 	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python2 \
-	&& pip install --upgrade pip==$PYTHON_PIP_VERSION \
+	&& pip install --no-cache-dir --upgrade pip==$PYTHON_PIP_VERSION \
 	&& find /usr/local \
 		\( -type d -a -name test -o -name tests \) \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
@@ -36,6 +36,6 @@ RUN set -x \
 	&& rm -rf /usr/src/python
 
 # install "virtualenv", since the vast majority of users of this image will want it
-RUN pip install virtualenv
+RUN pip install --no-cache-dir virtualenv
 
 CMD ["python2"]

--- a/2.7/onbuild/Dockerfile
+++ b/2.7/onbuild/Dockerfile
@@ -4,6 +4,6 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ONBUILD COPY requirements.txt /usr/src/app/
-ONBUILD RUN pip install -r requirements.txt
+ONBUILD RUN pip install --no-cache-dir -r requirements.txt
 
 ONBUILD COPY . /usr/src/app

--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -36,7 +36,7 @@ RUN set -x \
 	&& make install \
 	&& ldconfig \
 	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python2 \
-	&& pip install --upgrade pip==$PYTHON_PIP_VERSION \
+	&& pip install --no-cache-dir --upgrade pip==$PYTHON_PIP_VERSION \
 	&& find /usr/local \
 		\( -type d -a -name test -o -name tests \) \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
@@ -45,6 +45,6 @@ RUN set -x \
 	&& rm -rf /usr/src/python
 
 # install "virtualenv", since the vast majority of users of this image will want it
-RUN pip install virtualenv
+RUN pip install --no-cache-dir virtualenv
 
 CMD ["python2"]

--- a/2.7/wheezy/Dockerfile
+++ b/2.7/wheezy/Dockerfile
@@ -28,7 +28,7 @@ RUN set -x \
 	&& make install \
 	&& ldconfig \
 	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python2 \
-	&& pip install --upgrade pip==$PYTHON_PIP_VERSION \
+	&& pip install --no-cache-dir --upgrade pip==$PYTHON_PIP_VERSION \
 	&& find /usr/local \
 		\( -type d -a -name test -o -name tests \) \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
@@ -36,6 +36,6 @@ RUN set -x \
 	&& rm -rf /usr/src/python
 
 # install "virtualenv", since the vast majority of users of this image will want it
-RUN pip install virtualenv
+RUN pip install --no-cache-dir virtualenv
 
 CMD ["python2"]

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -28,7 +28,7 @@ RUN set -x \
 	&& make install \
 	&& ldconfig \
 	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python3 \
-	&& pip install --upgrade pip==$PYTHON_PIP_VERSION \
+	&& pip install --no-cache-dir --upgrade pip==$PYTHON_PIP_VERSION \
 	&& find /usr/local \
 		\( -type d -a -name test -o -name tests \) \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \

--- a/3.2/onbuild/Dockerfile
+++ b/3.2/onbuild/Dockerfile
@@ -4,6 +4,6 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ONBUILD COPY requirements.txt /usr/src/app/
-ONBUILD RUN pip install -r requirements.txt
+ONBUILD RUN pip install --no-cache-dir -r requirements.txt
 
 ONBUILD COPY . /usr/src/app

--- a/3.2/slim/Dockerfile
+++ b/3.2/slim/Dockerfile
@@ -36,7 +36,7 @@ RUN set -x \
 	&& make install \
 	&& ldconfig \
 	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python3 \
-	&& pip install --upgrade pip==$PYTHON_PIP_VERSION \
+	&& pip install --no-cache-dir --upgrade pip==$PYTHON_PIP_VERSION \
 	&& find /usr/local \
 		\( -type d -a -name test -o -name tests \) \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \

--- a/3.2/wheezy/Dockerfile
+++ b/3.2/wheezy/Dockerfile
@@ -28,7 +28,7 @@ RUN set -x \
 	&& make install \
 	&& ldconfig \
 	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python3 \
-	&& pip install --upgrade pip==$PYTHON_PIP_VERSION \
+	&& pip install --no-cache-dir --upgrade pip==$PYTHON_PIP_VERSION \
 	&& find /usr/local \
 		\( -type d -a -name test -o -name tests \) \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -28,7 +28,7 @@ RUN set -x \
 	&& make install \
 	&& ldconfig \
 	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python3 \
-	&& pip install --upgrade pip==$PYTHON_PIP_VERSION \
+	&& pip install --no-cache-dir --upgrade pip==$PYTHON_PIP_VERSION \
 	&& find /usr/local \
 		\( -type d -a -name test -o -name tests \) \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \

--- a/3.3/onbuild/Dockerfile
+++ b/3.3/onbuild/Dockerfile
@@ -4,6 +4,6 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ONBUILD COPY requirements.txt /usr/src/app/
-ONBUILD RUN pip install -r requirements.txt
+ONBUILD RUN pip install --no-cache-dir -r requirements.txt
 
 ONBUILD COPY . /usr/src/app

--- a/3.3/slim/Dockerfile
+++ b/3.3/slim/Dockerfile
@@ -36,7 +36,7 @@ RUN set -x \
 	&& make install \
 	&& ldconfig \
 	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python3 \
-	&& pip install --upgrade pip==$PYTHON_PIP_VERSION \
+	&& pip install --no-cache-dir --upgrade pip==$PYTHON_PIP_VERSION \
 	&& find /usr/local \
 		\( -type d -a -name test -o -name tests \) \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \

--- a/3.3/wheezy/Dockerfile
+++ b/3.3/wheezy/Dockerfile
@@ -28,7 +28,7 @@ RUN set -x \
 	&& make install \
 	&& ldconfig \
 	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python3 \
-	&& pip install --upgrade pip==$PYTHON_PIP_VERSION \
+	&& pip install --no-cache-dir --upgrade pip==$PYTHON_PIP_VERSION \
 	&& find /usr/local \
 		\( -type d -a -name test -o -name tests \) \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -27,7 +27,7 @@ RUN set -x \
 	&& make -j$(nproc) \
 	&& make install \
 	&& ldconfig \
-	&& pip3 install --upgrade pip==$PYTHON_PIP_VERSION \
+	&& pip3 install --no-cache-dir --upgrade pip==$PYTHON_PIP_VERSION \
 	&& find /usr/local \
 		\( -type d -a -name test -o -name tests \) \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \

--- a/3.4/onbuild/Dockerfile
+++ b/3.4/onbuild/Dockerfile
@@ -4,6 +4,6 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ONBUILD COPY requirements.txt /usr/src/app/
-ONBUILD RUN pip install -r requirements.txt
+ONBUILD RUN pip install --no-cache-dir -r requirements.txt
 
 ONBUILD COPY . /usr/src/app

--- a/3.4/slim/Dockerfile
+++ b/3.4/slim/Dockerfile
@@ -35,7 +35,7 @@ RUN set -x \
 	&& make -j$(nproc) \
 	&& make install \
 	&& ldconfig \
-	&& pip3 install --upgrade pip==$PYTHON_PIP_VERSION \
+	&& pip3 install --no-cache-dir --upgrade pip==$PYTHON_PIP_VERSION \
 	&& find /usr/local \
 		\( -type d -a -name test -o -name tests \) \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \

--- a/3.4/wheezy/Dockerfile
+++ b/3.4/wheezy/Dockerfile
@@ -27,7 +27,7 @@ RUN set -x \
 	&& make -j$(nproc) \
 	&& make install \
 	&& ldconfig \
-	&& pip3 install --upgrade pip==$PYTHON_PIP_VERSION \
+	&& pip3 install --no-cache-dir --upgrade pip==$PYTHON_PIP_VERSION \
 	&& find /usr/local \
 		\( -type d -a -name test -o -name tests \) \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \


### PR DESCRIPTION
This caching includes the file that was downloaded over http,
as well as this new wheel cache. Neither of which are valuable
and just add bloat into the resulting images. Similar to removing
the apt caches on disk at each layer. This also makes pip install's
a tiny bit faster since pip avoids trying to automatically create
wheels (which is fast itself, but again, unnecessary in this world).

See:
  - https://pip.pypa.io/en/latest/reference/pip_install.html#caching
  - https://pip.pypa.io/en/latest/reference/pip_install.html#wheel-cache