### PR TITLE
Add alpine to generate-stackbrew-library.sh also

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -31,7 +31,7 @@ for version in "${versions[@]}"; do
 		echo "$va: ${url}@${commit} $version"
 	done
 	
-	for variant in onbuild slim wheezy; do
+	for variant in onbuild slim alpine wheezy; do
 		[ -f "$version/$variant/Dockerfile" ] || continue
 		commit="$(cd "$version/$variant" && git log -1 --format='format:%H' -- Dockerfile $(awk 'toupper($1) == "COPY" { for (i = 2; i < NF; i++) { print $i } }' Dockerfile))"
 		echo


### PR DESCRIPTION
```
3.5.1-alpine: git://github.com/docker-library/python@9c5b00f106e87639857134945d87fc7fca5e02f9 3.5/alpine
3.5-alpine: git://github.com/docker-library/python@9c5b00f106e87639857134945d87fc7fca5e02f9 3.5/alpine
3-alpine: git://github.com/docker-library/python@9c5b00f106e87639857134945d87fc7fca5e02f9 3.5/alpine
alpine: git://github.com/docker-library/python@9c5b00f106e87639857134945d87fc7fca5e02f9 3.5/alpine
```