### PR TITLE
pip 8.0

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -13,7 +13,7 @@ ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 ENV PYTHON_VERSION 2.7.11
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 7.1.2
+ENV PYTHON_PIP_VERSION 8.0.3
 
 RUN set -ex \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \

--- a/2.7/alpine/Dockerfile
+++ b/2.7/alpine/Dockerfile
@@ -10,7 +10,7 @@ ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 ENV PYTHON_VERSION 2.7.11
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 7.1.2
+ENV PYTHON_PIP_VERSION 8.0.3
 
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps curl gnupg \

--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -19,7 +19,7 @@ ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 ENV PYTHON_VERSION 2.7.11
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 7.1.2
+ENV PYTHON_PIP_VERSION 8.0.3
 
 RUN set -ex \
 	&& buildDeps=' \

--- a/2.7/wheezy/Dockerfile
+++ b/2.7/wheezy/Dockerfile
@@ -13,7 +13,7 @@ ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 ENV PYTHON_VERSION 2.7.11
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 7.1.2
+ENV PYTHON_PIP_VERSION 8.0.3
 
 RUN set -ex \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -13,7 +13,7 @@ ENV GPG_KEY 26DEA9D4613391EF3E25C9FF0A5B101836580288
 ENV PYTHON_VERSION 3.3.6
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 7.1.2
+ENV PYTHON_PIP_VERSION 8.0.3
 
 RUN set -ex \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \

--- a/3.3/alpine/Dockerfile
+++ b/3.3/alpine/Dockerfile
@@ -10,7 +10,7 @@ ENV GPG_KEY 26DEA9D4613391EF3E25C9FF0A5B101836580288
 ENV PYTHON_VERSION 3.3.6
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 7.1.2
+ENV PYTHON_PIP_VERSION 8.0.3
 
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps curl gnupg \

--- a/3.3/slim/Dockerfile
+++ b/3.3/slim/Dockerfile
@@ -19,7 +19,7 @@ ENV GPG_KEY 26DEA9D4613391EF3E25C9FF0A5B101836580288
 ENV PYTHON_VERSION 3.3.6
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 7.1.2
+ENV PYTHON_PIP_VERSION 8.0.3
 
 RUN set -ex \
 	&& buildDeps=' \

--- a/3.3/wheezy/Dockerfile
+++ b/3.3/wheezy/Dockerfile
@@ -13,7 +13,7 @@ ENV GPG_KEY 26DEA9D4613391EF3E25C9FF0A5B101836580288
 ENV PYTHON_VERSION 3.3.6
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 7.1.2
+ENV PYTHON_PIP_VERSION 8.0.3
 
 RUN set -ex \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -13,7 +13,7 @@ ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.4.4
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 7.1.2
+ENV PYTHON_PIP_VERSION 8.0.3
 
 RUN set -ex \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \

--- a/3.4/alpine/Dockerfile
+++ b/3.4/alpine/Dockerfile
@@ -10,7 +10,7 @@ ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.4.4
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 7.1.2
+ENV PYTHON_PIP_VERSION 8.0.3
 
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps curl gnupg \

--- a/3.4/slim/Dockerfile
+++ b/3.4/slim/Dockerfile
@@ -19,7 +19,7 @@ ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.4.4
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 7.1.2
+ENV PYTHON_PIP_VERSION 8.0.3
 
 RUN set -ex \
 	&& buildDeps=' \

--- a/3.4/wheezy/Dockerfile
+++ b/3.4/wheezy/Dockerfile
@@ -13,7 +13,7 @@ ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.4.4
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 7.1.2
+ENV PYTHON_PIP_VERSION 8.0.3
 
 RUN set -ex \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -13,7 +13,7 @@ ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.5.1
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 7.1.2
+ENV PYTHON_PIP_VERSION 8.0.3
 
 RUN set -ex \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \

--- a/3.5/alpine/Dockerfile
+++ b/3.5/alpine/Dockerfile
@@ -10,7 +10,7 @@ ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.5.1
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 7.1.2
+ENV PYTHON_PIP_VERSION 8.0.3
 
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps curl gnupg \

--- a/3.5/slim/Dockerfile
+++ b/3.5/slim/Dockerfile
@@ -19,7 +19,7 @@ ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.5.1
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 7.1.2
+ENV PYTHON_PIP_VERSION 8.0.3
 
 RUN set -ex \
 	&& buildDeps=' \


### PR DESCRIPTION
https://pip.pypa.io/en/stable/news/#release-notes

pip 8.0 introduces some backwards incompatibilities, so not even entirely sure if this is a great idea.

But on the otherhand, we have no way of versioning `pip` independently from `python` in these builds.

So we may end up with someone tagging to a very specific `python:2.7.11` which had pip 7.1.2, then tomorrow, gets new build with 8.0.0 and breaks their container.

Thoughts?