### PR TITLE
Add missing build dependency for lzma module

### DIFF
--- a/3.3/alpine/Dockerfile
+++ b/3.3/alpine/Dockerfile
@@ -35,6 +35,7 @@ RUN set -ex \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
+		xz-dev \
 		zlib-dev \
 	&& cd /usr/src/python \
 	&& ./configure --enable-shared --enable-unicode=ucs4 \

--- a/3.3/slim/Dockerfile
+++ b/3.3/slim/Dockerfile
@@ -27,6 +27,7 @@ RUN set -ex \
 		gcc \
 		libbz2-dev \
 		libc6-dev \
+		liblzma-dev \
 		libncurses-dev \
 		libreadline-dev \
 		libsqlite3-dev \

--- a/3.4/alpine/Dockerfile
+++ b/3.4/alpine/Dockerfile
@@ -36,6 +36,7 @@ RUN set -ex \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
+		xz-dev \
 		zlib-dev \
 	&& cd /usr/src/python \
 	&& ./configure --enable-shared --enable-unicode=ucs4 \

--- a/3.4/slim/Dockerfile
+++ b/3.4/slim/Dockerfile
@@ -27,6 +27,7 @@ RUN set -ex \
 		gcc \
 		libbz2-dev \
 		libc6-dev \
+		liblzma-dev \
 		libncurses-dev \
 		libreadline-dev \
 		libsqlite3-dev \

--- a/3.5/alpine/Dockerfile
+++ b/3.5/alpine/Dockerfile
@@ -36,6 +36,7 @@ RUN set -ex \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
+		xz-dev \
 		zlib-dev \
 	&& cd /usr/src/python \
 	&& ./configure --enable-shared --enable-unicode=ucs4 \

--- a/3.5/slim/Dockerfile
+++ b/3.5/slim/Dockerfile
@@ -27,6 +27,7 @@ RUN set -ex \
 		gcc \
 		libbz2-dev \
 		libc6-dev \
+		liblzma-dev \
 		libncurses-dev \
 		libreadline-dev \
 		libsqlite3-dev \


### PR DESCRIPTION
Build dependency for `lzma` module in Python 3.3+ is missing on slim (`liblzma-dev`) and alpine (`xz-dev`) images, as @yosifkit mentioned in [#86](https://github.com/docker-library/python/issues/86#issuecomment-174711451).

This will close #86.