### PR TITLE
Explicitly empty ~/.cache

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -37,7 +37,7 @@ RUN set -ex \
 		\( -type d -a -name test -o -name tests \) \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		-exec rm -rf '{}' + \
-	&& rm -rf /usr/src/python
+	&& rm -rf /usr/src/python ~/.cache
 
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv

--- a/2.7/alpine/Dockerfile
+++ b/2.7/alpine/Dockerfile
@@ -56,6 +56,6 @@ RUN set -ex \
 	)" \
 	&& apk add --virtual .python-rundeps $runDeps \
 	&& apk del .build-deps .fetch-deps \
-	&& rm -rf /usr/src/python
+	&& rm -rf /usr/src/python ~/.cache
 
 CMD ["python2"]

--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -58,6 +58,6 @@ RUN set -ex \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		-exec rm -rf '{}' + \
 	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python
+	&& rm -rf /usr/src/python ~/.cache
 
 CMD ["python2"]

--- a/2.7/wheezy/Dockerfile
+++ b/2.7/wheezy/Dockerfile
@@ -37,7 +37,7 @@ RUN set -ex \
 		\( -type d -a -name test -o -name tests \) \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		-exec rm -rf '{}' + \
-	&& rm -rf /usr/src/python
+	&& rm -rf /usr/src/python ~/.cache
 
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -37,7 +37,7 @@ RUN set -ex \
 		\( -type d -a -name test -o -name tests \) \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		-exec rm -rf '{}' + \
-	&& rm -rf /usr/src/python
+	&& rm -rf /usr/src/python ~/.cache
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \

--- a/3.3/alpine/Dockerfile
+++ b/3.3/alpine/Dockerfile
@@ -56,7 +56,7 @@ RUN set -ex \
 	)" \
 	&& apk add --virtual .python-rundeps $runDeps \
 	&& apk del .build-deps .fetch-deps \
-	&& rm -rf /usr/src/python
+	&& rm -rf /usr/src/python ~/.cache
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \

--- a/3.3/slim/Dockerfile
+++ b/3.3/slim/Dockerfile
@@ -58,7 +58,7 @@ RUN set -ex \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		-exec rm -rf '{}' + \
 	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python
+	&& rm -rf /usr/src/python ~/.cache
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \

--- a/3.3/wheezy/Dockerfile
+++ b/3.3/wheezy/Dockerfile
@@ -37,7 +37,7 @@ RUN set -ex \
 		\( -type d -a -name test -o -name tests \) \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		-exec rm -rf '{}' + \
-	&& rm -rf /usr/src/python
+	&& rm -rf /usr/src/python ~/.cache
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -36,7 +36,7 @@ RUN set -ex \
 		\( -type d -a -name test -o -name tests \) \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		-exec rm -rf '{}' + \
-	&& rm -rf /usr/src/python
+	&& rm -rf /usr/src/python ~/.cache
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \

--- a/3.4/alpine/Dockerfile
+++ b/3.4/alpine/Dockerfile
@@ -56,7 +56,7 @@ RUN set -ex \
 	)" \
 	&& apk add --virtual .python-rundeps $runDeps \
 	&& apk del .build-deps \
-	&& rm -rf /usr/src/python
+	&& rm -rf /usr/src/python ~/.cache
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \

--- a/3.4/slim/Dockerfile
+++ b/3.4/slim/Dockerfile
@@ -57,7 +57,7 @@ RUN set -ex \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		-exec rm -rf '{}' + \
 	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python
+	&& rm -rf /usr/src/python ~/.cache
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \

--- a/3.4/wheezy/Dockerfile
+++ b/3.4/wheezy/Dockerfile
@@ -36,7 +36,7 @@ RUN set -ex \
 		\( -type d -a -name test -o -name tests \) \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		-exec rm -rf '{}' + \
-	&& rm -rf /usr/src/python
+	&& rm -rf /usr/src/python ~/.cache
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -36,7 +36,7 @@ RUN set -ex \
 		\( -type d -a -name test -o -name tests \) \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		-exec rm -rf '{}' + \
-	&& rm -rf /usr/src/python
+	&& rm -rf /usr/src/python ~/.cache
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \

--- a/3.5/alpine/Dockerfile
+++ b/3.5/alpine/Dockerfile
@@ -56,7 +56,7 @@ RUN set -ex \
 	)" \
 	&& apk add --virtual .python-rundeps $runDeps \
 	&& apk del .build-deps \
-	&& rm -rf /usr/src/python
+	&& rm -rf /usr/src/python ~/.cache
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \

--- a/3.5/slim/Dockerfile
+++ b/3.5/slim/Dockerfile
@@ -57,7 +57,7 @@ RUN set -ex \
 		-o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		-exec rm -rf '{}' + \
 	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python
+	&& rm -rf /usr/src/python ~/.cache
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \


### PR DESCRIPTION
This shaves off ~1.1MB off the container builds. We do --no-cache-dir on
`pip install`, but turns out, this isn't enough. Stuff from within
`get-pip.py` ends up leveraging the http cache as well, so we should
just nuke it entirely.