### PR TITLE
Add support for sqlite3 extension loading

### DIFF
--- a/3.5/alpine/Dockerfile
+++ b/3.5/alpine/Dockerfile
@@ -40,7 +40,7 @@ RUN set -ex \
 		xz-dev \
 		zlib-dev \
 	&& cd /usr/src/python \
-	&& ./configure --enable-shared --enable-unicode=ucs4 \
+	&& ./configure --enable-shared --enable-unicode=ucs4 --enable-loadable-sqlite-extensions \
 	&& make -j$(getconf _NPROCESSORS_ONLN) \
 	&& make install \
 	&& pip3 install --no-cache-dir --upgrade --ignore-installed pip==$PYTHON_PIP_VERSION \


### PR DESCRIPTION
[Run-Time Loadable Extensions](https://www.sqlite.org/loadext.html)

I'm not sure what the universe is for needing this, but it allows various things like [Spatialite](http://www.gaia-gis.it/gaia-sins/) to function at run-time with extensions.