### PR TITLE
Add libpq so that psycopg2 can be installed.

### DIFF
--- a/3.5/alpine/Dockerfile
+++ b/3.5/alpine/Dockerfile
@@ -30,6 +30,7 @@ RUN set -ex \
 		bzip2-dev \
 		gcc \
 		libc-dev \
+		libpq \
 		linux-headers \
 		make \
 		ncurses-dev \


### PR DESCRIPTION
libpq (https://pkgs.alpinelinux.org/packages?name=libpq) provides the pg_config binary which is required for psycopg2 to build.