### PR TITLE
Alpine: add tk as build dependency

### DIFF
--- a/2.7/alpine/Dockerfile
+++ b/2.7/alpine/Dockerfile
@@ -36,6 +36,7 @@ RUN set -ex \
 		readline-dev \
 		sqlite-dev \
 		tcl-dev \
+		tk \
 		tk-dev \
 		zlib-dev \
 	&& cd /usr/src/python \

--- a/3.3/alpine/Dockerfile
+++ b/3.3/alpine/Dockerfile
@@ -36,6 +36,7 @@ RUN set -ex \
 		readline-dev \
 		sqlite-dev \
 		tcl-dev \
+		tk \
 		tk-dev \
 		xz-dev \
 		zlib-dev \

--- a/3.4/alpine/Dockerfile
+++ b/3.4/alpine/Dockerfile
@@ -37,6 +37,7 @@ RUN set -ex \
 		readline-dev \
 		sqlite-dev \
 		tcl-dev \
+		tk \
 		tk-dev \
 		xz-dev \
 		zlib-dev \

--- a/3.5/alpine/Dockerfile
+++ b/3.5/alpine/Dockerfile
@@ -37,6 +37,7 @@ RUN set -ex \
 		readline-dev \
 		sqlite-dev \
 		tcl-dev \
+		tk \
 		tk-dev \
 		xz-dev \
 		zlib-dev \

--- a/3.6/alpine/Dockerfile
+++ b/3.6/alpine/Dockerfile
@@ -37,6 +37,7 @@ RUN set -ex \
 		readline-dev \
 		sqlite-dev \
 		tcl-dev \
+		tk \
 		tk-dev \
 		xz-dev \
 		zlib-dev \


### PR DESCRIPTION
In #127, `tcl-dev` and `tk-dev` were added as build dependencies so that the `tkinter` module could be built.

Unfortunately, the Alpine Linux `tk-dev` package doesn't include the actual `tk` libraries (only the headers) so the `tkinter` module still fails to build. The `tk` package _does_ include the relevant libraries. This is just an issue with the Alpine packages that should probably be fixed upstream (`tk-dev` should maybe depend on `tk`).

From the Travis logs for #127 for [`python:2.7-alpine`](https://travis-ci.org/docker-library/python/jobs/145567730):
```
Python build finished, but the necessary bits to build these modules were not found:
_bsddb             _tkinter           bsddb185        
dbm                dl                 gdbm            
imageop            nis                sunaudiodev     
```

From the Travis logs for #127 for [`python:2.7-docker`](https://travis-ci.org/docker-library/python/jobs/145567729):
```
Python build finished, but the necessary bits to build these modules were not found:
_bsddb             bsddb185           dbm             
dl                 gdbm               imageop         
sunaudiodev
```

From the Travis logs for this PR, after adding the `tk` package for [`python:2.7-alpine`]():
```
Python build finished, but the necessary bits to build these modules were not found:
_bsddb             bsddb185           dbm             
dl                 gdbm               imageop         
nis                sunaudiodev                        
```

This is a fairly obscure issue and I doubt many people (I am not one of them) are using `tkinter` on the Alpine images. I just had somehow had this issue with these packages before. Without this change the installation of `tcl-dev` and `tk-dev` is effectively not doing anything.