### PR TITLE
Use "dpkg-divert" instead of "purge" to avoid Debian's Python

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -1,7 +1,19 @@
 FROM buildpack-deps:jessie
 
-# remove several traces of debian python
-RUN apt-get purge -y python.*
+# divert many traces of Debian Python (so that they are not used by mistake)
+# https://bugs.debian.org/33263 :(
+RUN set -ex \
+	&& for bits in \
+#		/etc/python* \
+		/usr/bin/*2to3* \
+		/usr/bin/*python* \
+		/usr/bin/pdb* \
+		/usr/bin/py* \
+#		/usr/lib/python* \
+#		/usr/share/python \
+	; do \
+		dpkg-divert --rename "$bits"; \
+	done
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.

--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -1,8 +1,5 @@
 FROM debian:jessie
 
-# remove several traces of debian python
-RUN apt-get purge -y python.*
-
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8

--- a/2.7/wheezy/Dockerfile
+++ b/2.7/wheezy/Dockerfile
@@ -1,7 +1,19 @@
 FROM buildpack-deps:wheezy
 
-# remove several traces of debian python
-RUN apt-get purge -y python.*
+# divert many traces of Debian Python (so that they are not used by mistake)
+# https://bugs.debian.org/33263 :(
+RUN set -ex \
+	&& for bits in \
+#		/etc/python* \
+		/usr/bin/*2to3* \
+		/usr/bin/*python* \
+		/usr/bin/pdb* \
+		/usr/bin/py* \
+#		/usr/lib/python* \
+#		/usr/share/python \
+	; do \
+		dpkg-divert --rename "$bits"; \
+	done
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -1,7 +1,19 @@
 FROM buildpack-deps:jessie
 
-# remove several traces of debian python
-RUN apt-get purge -y python.*
+# divert many traces of Debian Python (so that they are not used by mistake)
+# https://bugs.debian.org/33263 :(
+RUN set -ex \
+	&& for bits in \
+#		/etc/python* \
+		/usr/bin/*2to3* \
+		/usr/bin/*python* \
+		/usr/bin/pdb* \
+		/usr/bin/py* \
+#		/usr/lib/python* \
+#		/usr/share/python \
+	; do \
+		dpkg-divert --rename "$bits"; \
+	done
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.

--- a/3.3/slim/Dockerfile
+++ b/3.3/slim/Dockerfile
@@ -1,8 +1,5 @@
 FROM debian:jessie
 
-# remove several traces of debian python
-RUN apt-get purge -y python.*
-
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8

--- a/3.3/wheezy/Dockerfile
+++ b/3.3/wheezy/Dockerfile
@@ -1,7 +1,19 @@
 FROM buildpack-deps:wheezy
 
-# remove several traces of debian python
-RUN apt-get purge -y python.*
+# divert many traces of Debian Python (so that they are not used by mistake)
+# https://bugs.debian.org/33263 :(
+RUN set -ex \
+	&& for bits in \
+#		/etc/python* \
+		/usr/bin/*2to3* \
+		/usr/bin/*python* \
+		/usr/bin/pdb* \
+		/usr/bin/py* \
+#		/usr/lib/python* \
+#		/usr/share/python \
+	; do \
+		dpkg-divert --rename "$bits"; \
+	done
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -1,7 +1,19 @@
 FROM buildpack-deps:jessie
 
-# remove several traces of debian python
-RUN apt-get purge -y python.*
+# divert many traces of Debian Python (so that they are not used by mistake)
+# https://bugs.debian.org/33263 :(
+RUN set -ex \
+	&& for bits in \
+#		/etc/python* \
+		/usr/bin/*2to3* \
+		/usr/bin/*python* \
+		/usr/bin/pdb* \
+		/usr/bin/py* \
+#		/usr/lib/python* \
+#		/usr/share/python \
+	; do \
+		dpkg-divert --rename "$bits"; \
+	done
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.

--- a/3.4/slim/Dockerfile
+++ b/3.4/slim/Dockerfile
@@ -1,8 +1,5 @@
 FROM debian:jessie
 
-# remove several traces of debian python
-RUN apt-get purge -y python.*
-
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8

--- a/3.4/wheezy/Dockerfile
+++ b/3.4/wheezy/Dockerfile
@@ -1,7 +1,19 @@
 FROM buildpack-deps:wheezy
 
-# remove several traces of debian python
-RUN apt-get purge -y python.*
+# divert many traces of Debian Python (so that they are not used by mistake)
+# https://bugs.debian.org/33263 :(
+RUN set -ex \
+	&& for bits in \
+#		/etc/python* \
+		/usr/bin/*2to3* \
+		/usr/bin/*python* \
+		/usr/bin/pdb* \
+		/usr/bin/py* \
+#		/usr/lib/python* \
+#		/usr/share/python \
+	; do \
+		dpkg-divert --rename "$bits"; \
+	done
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -1,7 +1,19 @@
 FROM buildpack-deps:jessie
 
-# remove several traces of debian python
-RUN apt-get purge -y python.*
+# divert many traces of Debian Python (so that they are not used by mistake)
+# https://bugs.debian.org/33263 :(
+RUN set -ex \
+	&& for bits in \
+#		/etc/python* \
+		/usr/bin/*2to3* \
+		/usr/bin/*python* \
+		/usr/bin/pdb* \
+		/usr/bin/py* \
+#		/usr/lib/python* \
+#		/usr/share/python \
+	; do \
+		dpkg-divert --rename "$bits"; \
+	done
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.

--- a/3.5/slim/Dockerfile
+++ b/3.5/slim/Dockerfile
@@ -1,8 +1,5 @@
 FROM debian:jessie
 
-# remove several traces of debian python
-RUN apt-get purge -y python.*
-
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -1,7 +1,19 @@
 FROM buildpack-deps:jessie
 
-# remove several traces of debian python
-RUN apt-get purge -y python.*
+# divert many traces of Debian Python (so that they are not used by mistake)
+# https://bugs.debian.org/33263 :(
+RUN set -ex \
+	&& for bits in \
+#		/etc/python* \
+		/usr/bin/*2to3* \
+		/usr/bin/*python* \
+		/usr/bin/pdb* \
+		/usr/bin/py* \
+#		/usr/lib/python* \
+#		/usr/share/python \
+	; do \
+		dpkg-divert --rename "$bits"; \
+	done
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.

--- a/3.6/slim/Dockerfile
+++ b/3.6/slim/Dockerfile
@@ -1,8 +1,5 @@
 FROM debian:jessie
 
-# remove several traces of debian python
-RUN apt-get purge -y python.*
-
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8


### PR DESCRIPTION
Fixes #129