### PR TITLE
Alpine: install ca-certificates

### DIFF
--- a/2.7/alpine/Dockerfile
+++ b/2.7/alpine/Dockerfile
@@ -4,6 +4,10 @@ FROM alpine:3.4
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
+# install ca-certificates so that HTTPS works consistently
+# the other runtime dependencies for Python are installed later
+RUN apk add --no-cache ca-certificates
+
 # gpg: key 18ADD4FF: public key "Benjamin Peterson <benjamin@python.org>" imported
 ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 

--- a/3.3/alpine/Dockerfile
+++ b/3.3/alpine/Dockerfile
@@ -4,6 +4,10 @@ FROM alpine:3.4
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
+# install ca-certificates so that HTTPS works consistently
+# the other runtime dependencies for Python are installed later
+RUN apk add --no-cache ca-certificates
+
 # gpg: key 36580288: public key "Georg Brandl (Python release signing key) <georg@python.org>" imported
 ENV GPG_KEY 26DEA9D4613391EF3E25C9FF0A5B101836580288
 

--- a/3.4/alpine/Dockerfile
+++ b/3.4/alpine/Dockerfile
@@ -4,6 +4,10 @@ FROM alpine:3.4
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
+# install ca-certificates so that HTTPS works consistently
+# the other runtime dependencies for Python are installed later
+RUN apk add --no-cache ca-certificates
+
 # gpg: key F73C700D: public key "Larry Hastings <larry@hastings.org>" imported
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 

--- a/3.5/alpine/Dockerfile
+++ b/3.5/alpine/Dockerfile
@@ -4,6 +4,10 @@ FROM alpine:3.4
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
+# install ca-certificates so that HTTPS works consistently
+# the other runtime dependencies for Python are installed later
+RUN apk add --no-cache ca-certificates
+
 # gpg: key F73C700D: public key "Larry Hastings <larry@hastings.org>" imported
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 

--- a/3.6/alpine/Dockerfile
+++ b/3.6/alpine/Dockerfile
@@ -4,6 +4,10 @@ FROM alpine:3.4
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
+# install ca-certificates so that HTTPS works consistently
+# the other runtime dependencies for Python are installed later
+RUN apk add --no-cache ca-certificates
+
 # gpg: key AA65421D: public key "Ned Deily (Python release signing key) <nad@acm.org>" imported
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 


### PR DESCRIPTION
Fixes #109 and hopefully the many related issues.

3.5:
- Before: 86.67 MB
- After: 87.95 MB

2.7:
- Before: 70.07 MB
- After: 71.35 MB

(i.e. adds 1.28MB, uncompressed)