### PR TITLE
Add build-time headers/packages for "import dbm" to work properly on 2.7 slim and alpine variants

### DIFF
--- a/2.7/alpine/Dockerfile
+++ b/2.7/alpine/Dockerfile
@@ -31,6 +31,7 @@ RUN set -ex \
 	&& apk add --no-cache --virtual .build-deps  \
 		bzip2-dev \
 		gcc \
+		gdbm-dev \
 		libc-dev \
 		linux-headers \
 		make \

--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -27,6 +27,7 @@ RUN set -ex \
 		gcc \
 		libbz2-dev \
 		libc6-dev \
+		libdb-dev \
 		libncurses-dev \
 		libreadline-dev \
 		libsqlite3-dev \


### PR DESCRIPTION
Fixes #105

(See also https://github.com/docker-library/official-images/pull/2033)