### PR TITLE
Add gdbm-dev to slim and alpine images

### DIFF
--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -10,6 +10,7 @@ ENV LANG C.UTF-8
 # runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
+		libgdbm3 \
 		libsqlite3-0 \
 		libssl1.0.0 \
 	&& rm -rf /var/lib/apt/lists/*

--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -26,6 +26,7 @@ RUN set -ex \
 		libbz2-dev \
 		libc6-dev \
 		libdb-dev \
+		libgdbm-dev \
 		libncurses-dev \
 		libreadline-dev \
 		libsqlite3-dev \

--- a/3.3/alpine/Dockerfile
+++ b/3.3/alpine/Dockerfile
@@ -43,6 +43,7 @@ RUN set -ex \
 	&& apk add --no-cache --virtual .build-deps  \
 		bzip2-dev \
 		gcc \
+		gdbm-dev \
 		libc-dev \
 		linux-headers \
 		make \

--- a/3.3/slim/Dockerfile
+++ b/3.3/slim/Dockerfile
@@ -31,6 +31,7 @@ RUN set -ex \
 		gcc \
 		libbz2-dev \
 		libc6-dev \
+		libgdbm-dev \
 		liblzma-dev \
 		libncurses-dev \
 		libreadline-dev \

--- a/3.3/slim/Dockerfile
+++ b/3.3/slim/Dockerfile
@@ -16,6 +16,7 @@ ENV LANG C.UTF-8
 # runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
+		libgdbm3 \
 		libsqlite3-0 \
 		libssl1.0.0 \
 	&& rm -rf /var/lib/apt/lists/*

--- a/3.4/alpine/Dockerfile
+++ b/3.4/alpine/Dockerfile
@@ -43,6 +43,7 @@ RUN set -ex \
 	&& apk add --no-cache --virtual .build-deps  \
 		bzip2-dev \
 		gcc \
+		gdbm-dev \
 		libc-dev \
 		linux-headers \
 		make \

--- a/3.4/slim/Dockerfile
+++ b/3.4/slim/Dockerfile
@@ -31,6 +31,7 @@ RUN set -ex \
 		gcc \
 		libbz2-dev \
 		libc6-dev \
+		libgdbm-dev \
 		liblzma-dev \
 		libncurses-dev \
 		libreadline-dev \

--- a/3.4/slim/Dockerfile
+++ b/3.4/slim/Dockerfile
@@ -16,6 +16,7 @@ ENV LANG C.UTF-8
 # runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
+		libgdbm3 \
 		libsqlite3-0 \
 		libssl1.0.0 \
 	&& rm -rf /var/lib/apt/lists/*

--- a/3.5/alpine/Dockerfile
+++ b/3.5/alpine/Dockerfile
@@ -43,6 +43,7 @@ RUN set -ex \
 	&& apk add --no-cache --virtual .build-deps  \
 		bzip2-dev \
 		gcc \
+		gdbm-dev \
 		libc-dev \
 		linux-headers \
 		make \

--- a/3.5/slim/Dockerfile
+++ b/3.5/slim/Dockerfile
@@ -31,6 +31,7 @@ RUN set -ex \
 		gcc \
 		libbz2-dev \
 		libc6-dev \
+		libgdbm-dev \
 		liblzma-dev \
 		libncurses-dev \
 		libreadline-dev \

--- a/3.5/slim/Dockerfile
+++ b/3.5/slim/Dockerfile
@@ -16,6 +16,7 @@ ENV LANG C.UTF-8
 # runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
+		libgdbm3 \
 		libsqlite3-0 \
 		libssl1.0.0 \
 	&& rm -rf /var/lib/apt/lists/*

--- a/3.6/alpine/Dockerfile
+++ b/3.6/alpine/Dockerfile
@@ -37,6 +37,7 @@ RUN set -ex \
 	&& apk add --no-cache --virtual .build-deps  \
 		bzip2-dev \
 		gcc \
+		gdbm-dev \
 		libc-dev \
 		linux-headers \
 		make \

--- a/3.6/slim/Dockerfile
+++ b/3.6/slim/Dockerfile
@@ -10,6 +10,7 @@ ENV LANG C.UTF-8
 # runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
+		libgdbm3 \
 		libsqlite3-0 \
 		libssl1.0.0 \
 	&& rm -rf /var/lib/apt/lists/*

--- a/3.6/slim/Dockerfile
+++ b/3.6/slim/Dockerfile
@@ -25,6 +25,7 @@ RUN set -ex \
 		gcc \
 		libbz2-dev \
 		libc6-dev \
+		libgdbm-dev \
 		liblzma-dev \
 		libncurses-dev \
 		libreadline-dev \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -37,6 +37,7 @@ RUN set -ex \
 	&& apk add --no-cache --virtual .build-deps  \
 		bzip2-dev \
 		gcc \
+		gdbm-dev \
 		libc-dev \
 		linux-headers \
 		make \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -10,6 +10,7 @@ ENV LANG C.UTF-8
 # runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
+		libgdbm3 \
 		libsqlite3-0 \
 		libssl1.0.0 \
 	&& rm -rf /var/lib/apt/lists/*

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -25,6 +25,7 @@ RUN set -ex \
 		gcc \
 		libbz2-dev \
 		libc6-dev \
+		libgdbm-dev \
 		liblzma-dev \
 		libncurses-dev \
 		libreadline-dev \


### PR DESCRIPTION
Happy green tests from https://github.com/docker-library/official-images/pull/2284.

 Non-slim, non-alpine images should still fail until a new buildpack-deps is created.