### PR TITLE
Update 3.6 to 3.6.0b3 and refactor update.sh to handle pre-releases in a saner manner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: bash
 services: docker
 
 env:
-  - VERSION=3.6 VARIANT=
-  - VERSION=3.6 VARIANT=slim
-  - VERSION=3.6 VARIANT=alpine
+  - VERSION=3.6-rc VARIANT=
+  - VERSION=3.6-rc VARIANT=slim
+  - VERSION=3.6-rc VARIANT=alpine
   - VERSION=3.5 VARIANT=
   - VERSION=3.5 VARIANT=slim
   - VERSION=3.5 VARIANT=alpine

--- a/3.6-rc/Dockerfile
+++ b/3.6-rc/Dockerfile
@@ -1,4 +1,10 @@
-FROM alpine:3.4
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM buildpack-deps:jessie
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
@@ -7,22 +13,24 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install ca-certificates so that HTTPS works consistently
-# the other runtime dependencies for Python are installed later
-RUN apk add --no-cache ca-certificates
+# runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		tcl \
+		tk \
+	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
-ENV PYTHON_VERSION 3.6.0b2
+ENV PYTHON_VERSION 3.6.0b3
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 8.1.2
 
 RUN set -ex \
-	&& apk add --no-cache --virtual .fetch-deps \
-		gnupg \
-		openssl \
-		tar \
-		xz \
+	&& buildDeps=' \
+		tcl-dev \
+		tk-dev \
+	' \
+	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\
 	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
 	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
@@ -34,33 +42,13 @@ RUN set -ex \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz \
 	\
-	&& apk add --no-cache --virtual .build-deps  \
-		bzip2-dev \
-		gcc \
-		gdbm-dev \
-		libc-dev \
-		linux-headers \
-		make \
-		ncurses-dev \
-		openssl \
-		openssl-dev \
-		pax-utils \
-		readline-dev \
-		sqlite-dev \
-		tcl-dev \
-		tk \
-		tk-dev \
-		xz-dev \
-		zlib-dev \
-# add build deps before removing fetch deps in case there's overlap
-	&& apk del .fetch-deps \
-	\
 	&& cd /usr/src/python \
 	&& ./configure \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
-	&& make -j$(getconf _NPROCESSORS_ONLN) \
+	&& make -j$(nproc) \
 	&& make install \
+	&& ldconfig \
 	\
 # explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
@@ -82,15 +70,7 @@ RUN set -ex \
 			-o \
 			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		\) -exec rm -rf '{}' + \
-	&& runDeps="$( \
-		scanelf --needed --nobanner --recursive /usr/local \
-			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
-			| sort -u \
-			| xargs -r apk info --installed \
-			| sort -u \
-	)" \
-	&& apk add --virtual .python-rundeps $runDeps \
-	&& apk del .build-deps \
+	&& apt-get purge -y --auto-remove $buildDeps \
 	&& rm -rf /usr/src/python ~/.cache
 
 # make some useful symlinks that are expected to exist

--- a/3.6-rc/alpine/Dockerfile
+++ b/3.6-rc/alpine/Dockerfile
@@ -1,4 +1,10 @@
-FROM debian:jessie
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM alpine:3.4
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
@@ -7,39 +13,22 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# runtime dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		ca-certificates \
-		libgdbm3 \
-		libsqlite3-0 \
-		libssl1.0.0 \
-	&& rm -rf /var/lib/apt/lists/*
+# install ca-certificates so that HTTPS works consistently
+# the other runtime dependencies for Python are installed later
+RUN apk add --no-cache ca-certificates
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
-ENV PYTHON_VERSION 3.6.0b2
+ENV PYTHON_VERSION 3.6.0b3
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 8.1.2
 
 RUN set -ex \
-	&& buildDeps=' \
-		gcc \
-		libbz2-dev \
-		libc6-dev \
-		libgdbm-dev \
-		liblzma-dev \
-		libncurses-dev \
-		libreadline-dev \
-		libsqlite3-dev \
-		libssl-dev \
-		make \
-		tcl-dev \
-		tk-dev \
-		wget \
-		xz-utils \
-		zlib1g-dev \
-	' \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	&& apk add --no-cache --virtual .fetch-deps \
+		gnupg \
+		openssl \
+		tar \
+		xz \
 	\
 	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
 	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
@@ -51,13 +40,33 @@ RUN set -ex \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz \
 	\
+	&& apk add --no-cache --virtual .build-deps  \
+		bzip2-dev \
+		gcc \
+		gdbm-dev \
+		libc-dev \
+		linux-headers \
+		make \
+		ncurses-dev \
+		openssl \
+		openssl-dev \
+		pax-utils \
+		readline-dev \
+		sqlite-dev \
+		tcl-dev \
+		tk \
+		tk-dev \
+		xz-dev \
+		zlib-dev \
+# add build deps before removing fetch deps in case there's overlap
+	&& apk del .fetch-deps \
+	\
 	&& cd /usr/src/python \
 	&& ./configure \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
-	&& make -j$(nproc) \
+	&& make -j$(getconf _NPROCESSORS_ONLN) \
 	&& make install \
-	&& ldconfig \
 	\
 # explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
@@ -79,7 +88,15 @@ RUN set -ex \
 			-o \
 			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		\) -exec rm -rf '{}' + \
-	&& apt-get purge -y --auto-remove $buildDeps \
+	&& runDeps="$( \
+		scanelf --needed --nobanner --recursive /usr/local \
+			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+			| sort -u \
+			| xargs -r apk info --installed \
+			| sort -u \
+	)" \
+	&& apk add --virtual .python-rundeps $runDeps \
+	&& apk del .build-deps \
 	&& rm -rf /usr/src/python ~/.cache
 
 # make some useful symlinks that are expected to exist

--- a/3.6-rc/onbuild/Dockerfile
+++ b/3.6-rc/onbuild/Dockerfile
@@ -1,4 +1,10 @@
-FROM python:3.6
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM python:3.6-rc
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/3.6-rc/slim/Dockerfile
+++ b/3.6-rc/slim/Dockerfile
@@ -1,4 +1,10 @@
-FROM buildpack-deps:jessie
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM debian:jessie
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
@@ -9,20 +15,35 @@ ENV LANG C.UTF-8
 
 # runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		tcl \
-		tk \
+		ca-certificates \
+		libgdbm3 \
+		libsqlite3-0 \
+		libssl1.0.0 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
-ENV PYTHON_VERSION 3.6.0b2
+ENV PYTHON_VERSION 3.6.0b3
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 8.1.2
 
 RUN set -ex \
 	&& buildDeps=' \
+		gcc \
+		libbz2-dev \
+		libc6-dev \
+		libgdbm-dev \
+		liblzma-dev \
+		libncurses-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		libssl-dev \
+		make \
 		tcl-dev \
 		tk-dev \
+		wget \
+		xz-utils \
+		zlib1g-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\

--- a/3.6-rc/windows/windowsservercore/Dockerfile
+++ b/3.6-rc/windows/windowsservercore/Dockerfile
@@ -1,8 +1,14 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
 FROM microsoft/windowsservercore
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
-ENV PYTHON_VERSION 3.6.0b2
+ENV PYTHON_VERSION 3.6.0b3
 ENV PYTHON_RELEASE 3.6.0
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,6 +2,7 @@
 set -eu
 
 declare -A aliases=(
+	[3.6-rc]='rc'
 	[3.5]='3 latest'
 	[2.7]='2'
 )


### PR DESCRIPTION
Closes #156

I've intentionally left the PIP update/discussion to #154 (since it's orthogonal to this bump)