### PR TITLE
Update 3.6.0rc2 to 3.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: bash
 services: docker
 
 env:
-  - VERSION=3.6-rc VARIANT=
-  - VERSION=3.6-rc VARIANT=slim
-  - VERSION=3.6-rc VARIANT=alpine
+  - VERSION=3.6 VARIANT=
+  - VERSION=3.6 VARIANT=slim
+  - VERSION=3.6 VARIANT=alpine
   - VERSION=3.5 VARIANT=
   - VERSION=3.5 VARIANT=slim
   - VERSION=3.5 VARIANT=alpine

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:jessie
+FROM buildpack-deps:jessie
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
@@ -15,35 +15,20 @@ ENV LANG C.UTF-8
 
 # runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		ca-certificates \
-		libgdbm3 \
-		libsqlite3-0 \
-		libssl1.0.0 \
+		tcl \
+		tk \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
-ENV PYTHON_VERSION 3.6.0rc2
+ENV PYTHON_VERSION 3.6.0
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
 
 RUN set -ex \
 	&& buildDeps=' \
-		gcc \
-		libbz2-dev \
-		libc6-dev \
-		libgdbm-dev \
-		liblzma-dev \
-		libncurses-dev \
-		libreadline-dev \
-		libsqlite3-dev \
-		libssl-dev \
-		make \
 		tcl-dev \
 		tk-dev \
-		wget \
-		xz-utils \
-		zlib1g-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\

--- a/3.6/alpine/Dockerfile
+++ b/3.6/alpine/Dockerfile
@@ -18,7 +18,7 @@ ENV LANG C.UTF-8
 RUN apk add --no-cache ca-certificates
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
-ENV PYTHON_VERSION 3.6.0rc2
+ENV PYTHON_VERSION 3.6.0
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1

--- a/3.6/onbuild/Dockerfile
+++ b/3.6/onbuild/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM python:3.6-rc
+FROM python:3.6
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/3.6/slim/Dockerfile
+++ b/3.6/slim/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:jessie
+FROM debian:jessie
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
@@ -15,20 +15,35 @@ ENV LANG C.UTF-8
 
 # runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		tcl \
-		tk \
+		ca-certificates \
+		libgdbm3 \
+		libsqlite3-0 \
+		libssl1.0.0 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
-ENV PYTHON_VERSION 3.6.0rc2
+ENV PYTHON_VERSION 3.6.0
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
 
 RUN set -ex \
 	&& buildDeps=' \
+		gcc \
+		libbz2-dev \
+		libc6-dev \
+		libgdbm-dev \
+		liblzma-dev \
+		libncurses-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		libssl-dev \
+		make \
 		tcl-dev \
 		tk-dev \
+		wget \
+		xz-utils \
+		zlib1g-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\

--- a/3.6/windows/windowsservercore/Dockerfile
+++ b/3.6/windows/windowsservercore/Dockerfile
@@ -8,7 +8,7 @@ FROM microsoft/windowsservercore
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
-ENV PYTHON_VERSION 3.6.0rc2
+ENV PYTHON_VERSION 3.6.0
 ENV PYTHON_RELEASE 3.6.0
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -3,7 +3,6 @@ set -eu
 
 declare -A aliases=(
 	[3.6]='3 latest'
-	[3.5]='3 5'
 	[2.7]='2'
 )
 

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,8 +2,8 @@
 set -eu
 
 declare -A aliases=(
-	[3.6-rc]='rc'
-	[3.5]='3 latest'
+	[3.6]='3 latest'
+	[3.5]='3 5'
 	[2.7]='2'
 )
 

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,6 +2,7 @@
 set -eu
 
 declare -A aliases=(
+	[3-7-rc]='rc'
 	[3.6]='3 latest'
 	[2.7]='2'
 )


### PR DESCRIPTION
Makes the [12/7 release of 3.6.0](https://www.python.org/ftp/python/3.6.0/) available on Docker Hub