### PR TITLE
Always run pip installer to get implicit deps

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -18,6 +18,8 @@ ENV PYTHON_VERSION 2.7.13
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_SETUPTOOLS_VERSION 35.0.1
+ENV PYTHON_WHEEL_VERSION 0.29.0
 
 RUN set -ex \
 	&& buildDeps=' \
@@ -50,7 +52,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/2.7/alpine/Dockerfile
+++ b/2.7/alpine/Dockerfile
@@ -16,6 +16,8 @@ ENV PYTHON_VERSION 2.7.13
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_SETUPTOOLS_VERSION 35.0.1
+ENV PYTHON_WHEEL_VERSION 0.29.0
 
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
@@ -67,7 +69,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -20,6 +20,8 @@ ENV PYTHON_VERSION 2.7.13
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_SETUPTOOLS_VERSION 35.0.1
+ENV PYTHON_WHEEL_VERSION 0.29.0
 
 RUN set -ex \
 	&& buildDeps=' \
@@ -65,7 +67,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/2.7/wheezy/Dockerfile
+++ b/2.7/wheezy/Dockerfile
@@ -18,6 +18,8 @@ ENV PYTHON_VERSION 2.7.13
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_SETUPTOOLS_VERSION 35.0.1
+ENV PYTHON_WHEEL_VERSION 0.29.0
 
 RUN set -ex \
 	&& buildDeps=' \
@@ -50,7 +52,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -24,6 +24,8 @@ ENV PYTHON_VERSION 3.3.6
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_SETUPTOOLS_VERSION 35.0.1
+ENV PYTHON_WHEEL_VERSION 0.29.0
 
 RUN set -ex \
 	&& buildDeps=' \
@@ -59,7 +61,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/3.3/alpine/Dockerfile
+++ b/3.3/alpine/Dockerfile
@@ -22,6 +22,8 @@ ENV PYTHON_VERSION 3.3.6
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_SETUPTOOLS_VERSION 35.0.1
+ENV PYTHON_WHEEL_VERSION 0.29.0
 
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
@@ -77,7 +79,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/3.3/slim/Dockerfile
+++ b/3.3/slim/Dockerfile
@@ -26,6 +26,8 @@ ENV PYTHON_VERSION 3.3.6
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_SETUPTOOLS_VERSION 35.0.1
+ENV PYTHON_WHEEL_VERSION 0.29.0
 
 RUN set -ex \
 	&& buildDeps=' \
@@ -74,7 +76,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/3.3/wheezy/Dockerfile
+++ b/3.3/wheezy/Dockerfile
@@ -24,6 +24,8 @@ ENV PYTHON_VERSION 3.3.6
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_SETUPTOOLS_VERSION 35.0.1
+ENV PYTHON_WHEEL_VERSION 0.29.0
 
 RUN set -ex \
 	&& buildDeps=' \
@@ -59,7 +61,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -24,6 +24,8 @@ ENV PYTHON_VERSION 3.4.6
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_SETUPTOOLS_VERSION 35.0.1
+ENV PYTHON_WHEEL_VERSION 0.29.0
 
 RUN set -ex \
 	&& buildDeps=' \
@@ -59,7 +61,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/3.4/alpine/Dockerfile
+++ b/3.4/alpine/Dockerfile
@@ -22,6 +22,8 @@ ENV PYTHON_VERSION 3.4.6
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_SETUPTOOLS_VERSION 35.0.1
+ENV PYTHON_WHEEL_VERSION 0.29.0
 
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
@@ -77,7 +79,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/3.4/slim/Dockerfile
+++ b/3.4/slim/Dockerfile
@@ -26,6 +26,8 @@ ENV PYTHON_VERSION 3.4.6
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_SETUPTOOLS_VERSION 35.0.1
+ENV PYTHON_WHEEL_VERSION 0.29.0
 
 RUN set -ex \
 	&& buildDeps=' \
@@ -74,7 +76,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/3.4/wheezy/Dockerfile
+++ b/3.4/wheezy/Dockerfile
@@ -24,6 +24,8 @@ ENV PYTHON_VERSION 3.4.6
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_SETUPTOOLS_VERSION 35.0.1
+ENV PYTHON_WHEEL_VERSION 0.29.0
 
 RUN set -ex \
 	&& buildDeps=' \
@@ -59,7 +61,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -24,6 +24,8 @@ ENV PYTHON_VERSION 3.5.3
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_SETUPTOOLS_VERSION 35.0.1
+ENV PYTHON_WHEEL_VERSION 0.29.0
 
 RUN set -ex \
 	&& buildDeps=' \
@@ -59,7 +61,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/3.5/alpine/Dockerfile
+++ b/3.5/alpine/Dockerfile
@@ -22,6 +22,8 @@ ENV PYTHON_VERSION 3.5.3
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_SETUPTOOLS_VERSION 35.0.1
+ENV PYTHON_WHEEL_VERSION 0.29.0
 
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
@@ -77,7 +79,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/3.5/slim/Dockerfile
+++ b/3.5/slim/Dockerfile
@@ -26,6 +26,8 @@ ENV PYTHON_VERSION 3.5.3
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_SETUPTOOLS_VERSION 35.0.1
+ENV PYTHON_WHEEL_VERSION 0.29.0
 
 RUN set -ex \
 	&& buildDeps=' \
@@ -74,7 +76,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/3.5/windows/windowsservercore/Dockerfile
+++ b/3.5/windows/windowsservercore/Dockerfile
@@ -13,6 +13,8 @@ ENV PYTHON_RELEASE 3.5.3
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_SETUPTOOLS_VERSION 35.0.1
+ENV PYTHON_WHEEL_VERSION 0.29.0
 
 RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env:PYTHON_RELEASE, $env:PYTHON_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
@@ -40,12 +42,16 @@ RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env
 	Write-Host 'Removing ...'; \
 	Remove-Item python.exe -Force; \
 	\
-	$pipInstall = ('pip=={0}' -f $env:PYTHON_PIP_VERSION); \
-	Write-Host ('Installing {0} ...' -f $pipInstall); \
+	Write-Host ('Installing pip=={0} ...' -f $env:PYTHON_PIP_VERSION); \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	pip install --no-cache-dir --upgrade --force-reinstall $pipInstall; \
+# (using "python -m pip" instead of "pip" to avoid pip trying to remove itself while it's running; see also https://pip.readthedocs.io/en/stable/installing/#id6)
+	python -m pip install --no-cache-dir --upgrade --force-reinstall \
+		('pip=={0}' -f $env:PYTHON_PIP_VERSION) \
+		('setuptools=={0}' -f $env:PYTHON_SETUPTOOLS_VERSION) \
+		('wheel=={0}' -f $env:PYTHON_WHEEL_VERSION) \
+	; \
 	\
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -24,6 +24,8 @@ ENV PYTHON_VERSION 3.6.1
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_SETUPTOOLS_VERSION 35.0.1
+ENV PYTHON_WHEEL_VERSION 0.29.0
 
 RUN set -ex \
 	&& buildDeps=' \
@@ -59,7 +61,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/3.6/alpine/Dockerfile
+++ b/3.6/alpine/Dockerfile
@@ -22,6 +22,8 @@ ENV PYTHON_VERSION 3.6.1
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_SETUPTOOLS_VERSION 35.0.1
+ENV PYTHON_WHEEL_VERSION 0.29.0
 
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
@@ -77,7 +79,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/3.6/slim/Dockerfile
+++ b/3.6/slim/Dockerfile
@@ -26,6 +26,8 @@ ENV PYTHON_VERSION 3.6.1
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_SETUPTOOLS_VERSION 35.0.1
+ENV PYTHON_WHEEL_VERSION 0.29.0
 
 RUN set -ex \
 	&& buildDeps=' \
@@ -74,7 +76,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/3.6/windows/windowsservercore/Dockerfile
+++ b/3.6/windows/windowsservercore/Dockerfile
@@ -13,6 +13,8 @@ ENV PYTHON_RELEASE 3.6.1
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_SETUPTOOLS_VERSION 35.0.1
+ENV PYTHON_WHEEL_VERSION 0.29.0
 
 RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env:PYTHON_RELEASE, $env:PYTHON_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
@@ -40,12 +42,16 @@ RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env
 	Write-Host 'Removing ...'; \
 	Remove-Item python.exe -Force; \
 	\
-	$pipInstall = ('pip=={0}' -f $env:PYTHON_PIP_VERSION); \
-	Write-Host ('Installing {0} ...' -f $pipInstall); \
+	Write-Host ('Installing pip=={0} ...' -f $env:PYTHON_PIP_VERSION); \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	pip install --no-cache-dir --upgrade --force-reinstall $pipInstall; \
+# (using "python -m pip" instead of "pip" to avoid pip trying to remove itself while it's running; see also https://pip.readthedocs.io/en/stable/installing/#id6)
+	python -m pip install --no-cache-dir --upgrade --force-reinstall \
+		('pip=={0}' -f $env:PYTHON_PIP_VERSION) \
+		('setuptools=={0}' -f $env:PYTHON_SETUPTOOLS_VERSION) \
+		('wheel=={0}' -f $env:PYTHON_WHEEL_VERSION) \
+	; \
 	\
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -16,6 +16,8 @@ ENV PYTHON_VERSION %%PLACEHOLDER%%
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION %%PLACEHOLDER%%
+ENV PYTHON_SETUPTOOLS_VERSION %%PLACEHOLDER%%
+ENV PYTHON_WHEEL_VERSION %%PLACEHOLDER%%
 
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
@@ -71,7 +73,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -18,6 +18,8 @@ ENV PYTHON_VERSION %%PLACEHOLDER%%
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION %%PLACEHOLDER%%
+ENV PYTHON_SETUPTOOLS_VERSION %%PLACEHOLDER%%
+ENV PYTHON_WHEEL_VERSION %%PLACEHOLDER%%
 
 RUN set -ex \
 	&& buildDeps=' \
@@ -53,7 +55,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -20,6 +20,8 @@ ENV PYTHON_VERSION %%PLACEHOLDER%%
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION %%PLACEHOLDER%%
+ENV PYTHON_SETUPTOOLS_VERSION %%PLACEHOLDER%%
+ENV PYTHON_WHEEL_VERSION %%PLACEHOLDER%%
 
 RUN set -ex \
 	&& buildDeps=' \
@@ -68,7 +70,10 @@ RUN set -ex \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
+		"pip==$PYTHON_PIP_VERSION" \
+		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		"wheel==$PYTHON_WHEEL_VERSION" \
 	\
 	&& find /usr/local -depth \
 		\( \

--- a/Dockerfile-windowsservercore.template
+++ b/Dockerfile-windowsservercore.template
@@ -7,6 +7,8 @@ ENV PYTHON_RELEASE %%PLACEHOLDER%%
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION %%PLACEHOLDER%%
+ENV PYTHON_SETUPTOOLS_VERSION %%PLACEHOLDER%%
+ENV PYTHON_WHEEL_VERSION %%PLACEHOLDER%%
 
 RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env:PYTHON_RELEASE, $env:PYTHON_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
@@ -34,12 +36,16 @@ RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env
 	Write-Host 'Removing ...'; \
 	Remove-Item python.exe -Force; \
 	\
-	$pipInstall = ('pip=={0}' -f $env:PYTHON_PIP_VERSION); \
-	Write-Host ('Installing {0} ...' -f $pipInstall); \
+	Write-Host ('Installing pip=={0} ...' -f $env:PYTHON_PIP_VERSION); \
 # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	pip install --no-cache-dir --upgrade --force-reinstall $pipInstall; \
+# (using "python -m pip" instead of "pip" to avoid pip trying to remove itself while it's running; see also https://pip.readthedocs.io/en/stable/installing/#id6)
+	python -m pip install --no-cache-dir --upgrade --force-reinstall \
+		('pip=={0}' -f $env:PYTHON_PIP_VERSION) \
+		('setuptools=={0}' -f $env:PYTHON_SETUPTOOLS_VERSION) \
+		('wheel=={0}' -f $env:PYTHON_WHEEL_VERSION) \
+	; \
 	\
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \

--- a/update.sh
+++ b/update.sh
@@ -32,7 +32,9 @@ if [ ${#versions[@]} -eq 0 ]; then
 fi
 versions=( "${versions[@]%/}" )
 
-pipVersion="$(curl -fsSL 'https://pypi.python.org/pypi/pip/json' | awk -F '"' '$2 == "version" { print $4 }')"
+pipVersion="$(curl -fsSL 'https://pypi.org/pypi/pip/json' | jq -r .info.version)"
+setuptoolsVersion="$(curl -fsSL 'https://pypi.org/pypi/setuptools/json' | jq -r .info.version)"
+wheelVersion="$(curl -fsSL 'https://pypi.org/pypi/wheel/json' | jq -r .info.version)"
 
 generated_warning() {
 	cat <<-EOH
@@ -103,6 +105,8 @@ for version in "${versions[@]}"; do
 				-e 's/^(ENV PYTHON_VERSION) .*/\1 '"$fullVersion"'/' \
 				-e 's/^(ENV PYTHON_RELEASE) .*/\1 '"${fullVersion%%[a-z]*}"'/' \
 				-e 's/^(ENV PYTHON_PIP_VERSION) .*/\1 '"$pipVersion"'/' \
+				-e 's/^(ENV PYTHON_SETUPTOOLS_VERSION) .*/\1 '"$setuptoolsVersion"'/' \
+				-e 's/^(ENV PYTHON_WHEEL_VERSION) .*/\1 '"$wheelVersion"'/' \
 				-e 's/^(FROM python):.*/\1:'"$version"'/' \
 				"$version"/{,*/,*/*/}Dockerfile
 		)


### PR DESCRIPTION
Unconditionally executing the contents of [this `if` block](https://github.com/docker-library/python/blob/32e920eb13714a9aeff2e016fb467901222d17b5/Dockerfile-alpine.template#L66) results in the installation of `wheel` (consistent with <= 3.3 images) without over-zealous overhead:

```
[...] # end of make install output
Successfully installed pip-9.0.1 setuptools-28.8.0
+ wget -O /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py
Connecting to bootstrap.pypa.io (151.101.0.175:443)
get-pip.py           100% |*******************************|  1558k  0:00:00 ETA
+ python3 /tmp/get-pip.py pip==9.0.1
Requirement already up-to-date: pip==9.0.1 in /usr/local/lib/python3.6/site-packages
Collecting wheel
  Downloading wheel-0.29.0-py2.py3-none-any.whl (66kB)
Installing collected packages: wheel
Successfully installed wheel-0.29.0
+ rm /tmp/get-pip.py
[...]
```

Fixes #141, #170