### PR TITLE
Fix segmentation fault when building Python 3.6 image

### DIFF
--- a/3.6/alpine/Dockerfile
+++ b/3.6/alpine/Dockerfile
@@ -58,11 +58,19 @@ RUN set -ex \
 		tk-dev \
 		xz-dev \
 		zlib-dev \
+		libffi-dev \
+		expat-dev \
 # add build deps before removing fetch deps in case there's overlap
 	&& apk del .fetch-deps \
 	\
 	&& cd /usr/src/python \
+	&& rm -r Modules/expat \
+		Modules/zlib \
+		Modules/_ctypes/darwin* \
+		Modules/_ctypes/libffi* \
 	&& ./configure \
+		--with-system-ffi \
+		--with-system-expat \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
 	&& make -j$(getconf _NPROCESSORS_ONLN) \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -52,11 +52,19 @@ RUN set -ex \
 		tk-dev \
 		xz-dev \
 		zlib-dev \
+		libffi-dev \
+		expat-dev \
 # add build deps before removing fetch deps in case there's overlap
 	&& apk del .fetch-deps \
 	\
 	&& cd /usr/src/python \
+	&& rm -r Modules/expat \
+		Modules/zlib \
+		Modules/_ctypes/darwin* \
+		Modules/_ctypes/libffi* \
 	&& ./configure \
+		--with-system-ffi \
+		--with-system-expat \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
 	&& make -j$(getconf _NPROCESSORS_ONLN) \


### PR DESCRIPTION
I'm not 100% sure what the guidelines or rules are around PRs like this, happy to make any adjustments that might be required to get this merged.

This fixes the issues reported in #160 for the Alpine build. For Python
3.6, the build succeeds but test illustrate that `ctypes` related test
fail with segmentation faults. This also prevents optimized builds
because they rely on a full run of the test suite.

The fix is based on the release candidate build of Python 3.6.1 in
Alpine Edge. It switches to system libraries for `libffi` and `expat` in
the same way it's used in [the Alpine build
file](https://git.alpinelinux.org/cgit/aports/tree/main/python3/APKBUILD).