### PR TITLE
Switch to unconditional invocation of "get-pip.py"

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -16,11 +16,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 ENV PYTHON_VERSION 2.7.13
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-ENV PYTHON_SETUPTOOLS_VERSION 35.0.2
-ENV PYTHON_WHEEL_VERSION 0.29.0
-
 RUN set -ex \
 	&& buildDeps=' \
 		tcl-dev \
@@ -42,20 +37,11 @@ RUN set -ex \
 	&& ./configure \
 		--enable-shared \
 		--enable-unicode=ucs4 \
-	&& make -j$(nproc) \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
 	\
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python2 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
+	&& apt-get purge -y --auto-remove $buildDeps \
 	\
 	&& find /usr/local -depth \
 		\( \
@@ -63,8 +49,29 @@ RUN set -ex \
 			-o \
 			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		\) -exec rm -rf '{}' + \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python ~/.cache
+	&& rm -rf /usr/src/python
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN set -ex; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv

--- a/2.7/alpine/Dockerfile
+++ b/2.7/alpine/Dockerfile
@@ -14,11 +14,6 @@ RUN apk add --no-cache ca-certificates
 ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 ENV PYTHON_VERSION 2.7.13
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-ENV PYTHON_SETUPTOOLS_VERSION 35.0.2
-ENV PYTHON_WHEEL_VERSION 0.29.0
-
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
@@ -60,26 +55,9 @@ RUN set -ex \
 	&& ./configure \
 		--enable-shared \
 		--enable-unicode=ucs4 \
-	&& make -j$(getconf _NPROCESSORS_ONLN) \
+	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
 	&& make install \
 	\
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python2 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
-	\
-	&& find /usr/local -depth \
-		\( \
-			\( -type d -a -name test -o -name tests \) \
-			-o \
-			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-		\) -exec rm -rf '{}' + \
 	&& runDeps="$( \
 		scanelf --needed --nobanner --recursive /usr/local \
 			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
@@ -89,6 +67,39 @@ RUN set -ex \
 	)" \
 	&& apk add --virtual .python-rundeps $runDeps \
 	&& apk del .build-deps \
-	&& rm -rf /usr/src/python ~/.cache
+	\
+	&& find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' + \
+	&& rm -rf /usr/src/python
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN set -ex; \
+	\
+	apk add --no-cache --virtual .fetch-deps openssl; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	apk del .fetch-deps; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["python2"]

--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -18,11 +18,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 ENV PYTHON_VERSION 2.7.13
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-ENV PYTHON_SETUPTOOLS_VERSION 35.0.2
-ENV PYTHON_WHEEL_VERSION 0.29.0
-
 RUN set -ex \
 	&& buildDeps=' \
 		gcc \
@@ -57,20 +52,11 @@ RUN set -ex \
 	&& ./configure \
 		--enable-shared \
 		--enable-unicode=ucs4 \
-	&& make -j$(nproc) \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
 	\
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python2 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
+	&& apt-get purge -y --auto-remove $buildDeps \
 	\
 	&& find /usr/local -depth \
 		\( \
@@ -78,7 +64,34 @@ RUN set -ex \
 			-o \
 			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		\) -exec rm -rf '{}' + \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python ~/.cache
+	&& rm -rf /usr/src/python
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends wget; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	apt-get purge -y --auto-remove wget; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["python2"]

--- a/2.7/wheezy/Dockerfile
+++ b/2.7/wheezy/Dockerfile
@@ -16,11 +16,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 ENV PYTHON_VERSION 2.7.13
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-ENV PYTHON_SETUPTOOLS_VERSION 35.0.2
-ENV PYTHON_WHEEL_VERSION 0.29.0
-
 RUN set -ex \
 	&& buildDeps=' \
 		tcl-dev \
@@ -42,20 +37,11 @@ RUN set -ex \
 	&& ./configure \
 		--enable-shared \
 		--enable-unicode=ucs4 \
-	&& make -j$(nproc) \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
 	\
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python2 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
+	&& apt-get purge -y --auto-remove $buildDeps \
 	\
 	&& find /usr/local -depth \
 		\( \
@@ -63,8 +49,29 @@ RUN set -ex \
 			-o \
 			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		\) -exec rm -rf '{}' + \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python ~/.cache
+	&& rm -rf /usr/src/python
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN set -ex; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv

--- a/2.7/windows/windowsservercore/Dockerfile
+++ b/2.7/windows/windowsservercore/Dockerfile
@@ -5,9 +5,6 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 ENV PYTHON_VERSION 2.7.13
 ENV PYTHON_RELEASE 2.7.13
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-
 RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}.amd64.msi' -f $env:PYTHON_RELEASE, $env:PYTHON_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	(New-Object System.Net.WebClient).DownloadFile($url, 'python.msi'); \
@@ -34,10 +31,18 @@ RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}.amd64.msi' -f $env
 	Write-Host 'Removing ...'; \
 	Remove-Item python.msi -Force; \
 	\
-	$pipInstall = ('pip=={0}' -f $env:PYTHON_PIP_VERSION); \
-	Write-Host ('Installing {0} ...' -f $pipInstall); \
+	Write-Host 'Complete.';
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN Write-Host ('Installing pip=={0} ...' -f $env:PYTHON_PIP_VERSION); \
 	(New-Object System.Net.WebClient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', 'get-pip.py'); \
-	python get-pip.py $pipInstall; \
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		('pip=={0}' -f $env:PYTHON_PIP_VERSION) \
+	; \
 	Remove-Item get-pip.py -Force; \
 	\
 	Write-Host 'Verifying pip install ...'; \

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -22,11 +22,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV GPG_KEY 26DEA9D4613391EF3E25C9FF0A5B101836580288
 ENV PYTHON_VERSION 3.3.6
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-ENV PYTHON_SETUPTOOLS_VERSION 35.0.2
-ENV PYTHON_WHEEL_VERSION 0.29.0
-
 RUN set -ex \
 	&& buildDeps=' \
 		tcl-dev \
@@ -48,23 +43,12 @@ RUN set -ex \
 	&& ./configure \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
-	&& make -j$(nproc) \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
 	\
-# explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
-	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python3 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-	; fi \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
+	&& apt-get purge -y --auto-remove $buildDeps \
 	\
 	&& find /usr/local -depth \
 		\( \
@@ -72,15 +56,35 @@ RUN set -ex \
 			-o \
 			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		\) -exec rm -rf '{}' + \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python ~/.cache
+	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \
-	&& { [ -e easy_install ] || ln -s easy_install-* easy_install; } \
 	&& ln -s idle3 idle \
 	&& ln -s pydoc3 pydoc \
 	&& ln -s python3 python \
 	&& ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN set -ex; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["python3"]

--- a/3.3/alpine/Dockerfile
+++ b/3.3/alpine/Dockerfile
@@ -20,11 +20,6 @@ RUN apk add --no-cache ca-certificates
 ENV GPG_KEY 26DEA9D4613391EF3E25C9FF0A5B101836580288
 ENV PYTHON_VERSION 3.3.6
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-ENV PYTHON_SETUPTOOLS_VERSION 35.0.2
-ENV PYTHON_WHEEL_VERSION 0.29.0
-
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
@@ -67,29 +62,10 @@ RUN set -ex \
 	&& ./configure \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
-	&& make -j$(getconf _NPROCESSORS_ONLN) \
+		--without-ensurepip \
+	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
 	&& make install \
 	\
-# explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
-	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python3 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-	; fi \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
-	\
-	&& find /usr/local -depth \
-		\( \
-			\( -type d -a -name test -o -name tests \) \
-			-o \
-			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-		\) -exec rm -rf '{}' + \
 	&& runDeps="$( \
 		scanelf --needed --nobanner --recursive /usr/local \
 			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
@@ -99,14 +75,46 @@ RUN set -ex \
 	)" \
 	&& apk add --virtual .python-rundeps $runDeps \
 	&& apk del .build-deps \
-	&& rm -rf /usr/src/python ~/.cache
+	\
+	&& find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' + \
+	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \
-	&& { [ -e easy_install ] || ln -s easy_install-* easy_install; } \
 	&& ln -s idle3 idle \
 	&& ln -s pydoc3 pydoc \
 	&& ln -s python3 python \
 	&& ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN set -ex; \
+	\
+	apk add --no-cache --virtual .fetch-deps openssl; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	apk del .fetch-deps; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["python3"]

--- a/3.3/slim/Dockerfile
+++ b/3.3/slim/Dockerfile
@@ -24,11 +24,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV GPG_KEY 26DEA9D4613391EF3E25C9FF0A5B101836580288
 ENV PYTHON_VERSION 3.3.6
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-ENV PYTHON_SETUPTOOLS_VERSION 35.0.2
-ENV PYTHON_WHEEL_VERSION 0.29.0
-
 RUN set -ex \
 	&& buildDeps=' \
 		gcc \
@@ -63,23 +58,12 @@ RUN set -ex \
 	&& ./configure \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
-	&& make -j$(nproc) \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
 	\
-# explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
-	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python3 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-	; fi \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
+	&& apt-get purge -y --auto-remove $buildDeps \
 	\
 	&& find /usr/local -depth \
 		\( \
@@ -87,15 +71,41 @@ RUN set -ex \
 			-o \
 			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		\) -exec rm -rf '{}' + \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python ~/.cache
+	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \
-	&& { [ -e easy_install ] || ln -s easy_install-* easy_install; } \
 	&& ln -s idle3 idle \
 	&& ln -s pydoc3 pydoc \
 	&& ln -s python3 python \
 	&& ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends wget; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	apt-get purge -y --auto-remove wget; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["python3"]

--- a/3.3/wheezy/Dockerfile
+++ b/3.3/wheezy/Dockerfile
@@ -22,11 +22,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV GPG_KEY 26DEA9D4613391EF3E25C9FF0A5B101836580288
 ENV PYTHON_VERSION 3.3.6
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-ENV PYTHON_SETUPTOOLS_VERSION 35.0.2
-ENV PYTHON_WHEEL_VERSION 0.29.0
-
 RUN set -ex \
 	&& buildDeps=' \
 		tcl-dev \
@@ -48,23 +43,12 @@ RUN set -ex \
 	&& ./configure \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
-	&& make -j$(nproc) \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
 	\
-# explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
-	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python3 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-	; fi \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
+	&& apt-get purge -y --auto-remove $buildDeps \
 	\
 	&& find /usr/local -depth \
 		\( \
@@ -72,15 +56,35 @@ RUN set -ex \
 			-o \
 			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		\) -exec rm -rf '{}' + \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python ~/.cache
+	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \
-	&& { [ -e easy_install ] || ln -s easy_install-* easy_install; } \
 	&& ln -s idle3 idle \
 	&& ln -s pydoc3 pydoc \
 	&& ln -s python3 python \
 	&& ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN set -ex; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["python3"]

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -22,11 +22,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.4.6
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-ENV PYTHON_SETUPTOOLS_VERSION 35.0.2
-ENV PYTHON_WHEEL_VERSION 0.29.0
-
 RUN set -ex \
 	&& buildDeps=' \
 		tcl-dev \
@@ -48,23 +43,12 @@ RUN set -ex \
 	&& ./configure \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
-	&& make -j$(nproc) \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
 	\
-# explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
-	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python3 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-	; fi \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
+	&& apt-get purge -y --auto-remove $buildDeps \
 	\
 	&& find /usr/local -depth \
 		\( \
@@ -72,15 +56,35 @@ RUN set -ex \
 			-o \
 			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		\) -exec rm -rf '{}' + \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python ~/.cache
+	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \
-	&& { [ -e easy_install ] || ln -s easy_install-* easy_install; } \
 	&& ln -s idle3 idle \
 	&& ln -s pydoc3 pydoc \
 	&& ln -s python3 python \
 	&& ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN set -ex; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["python3"]

--- a/3.4/alpine/Dockerfile
+++ b/3.4/alpine/Dockerfile
@@ -20,11 +20,6 @@ RUN apk add --no-cache ca-certificates
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.4.6
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-ENV PYTHON_SETUPTOOLS_VERSION 35.0.2
-ENV PYTHON_WHEEL_VERSION 0.29.0
-
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
@@ -67,29 +62,10 @@ RUN set -ex \
 	&& ./configure \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
-	&& make -j$(getconf _NPROCESSORS_ONLN) \
+		--without-ensurepip \
+	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
 	&& make install \
 	\
-# explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
-	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python3 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-	; fi \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
-	\
-	&& find /usr/local -depth \
-		\( \
-			\( -type d -a -name test -o -name tests \) \
-			-o \
-			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-		\) -exec rm -rf '{}' + \
 	&& runDeps="$( \
 		scanelf --needed --nobanner --recursive /usr/local \
 			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
@@ -99,14 +75,46 @@ RUN set -ex \
 	)" \
 	&& apk add --virtual .python-rundeps $runDeps \
 	&& apk del .build-deps \
-	&& rm -rf /usr/src/python ~/.cache
+	\
+	&& find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' + \
+	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \
-	&& { [ -e easy_install ] || ln -s easy_install-* easy_install; } \
 	&& ln -s idle3 idle \
 	&& ln -s pydoc3 pydoc \
 	&& ln -s python3 python \
 	&& ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN set -ex; \
+	\
+	apk add --no-cache --virtual .fetch-deps openssl; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	apk del .fetch-deps; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["python3"]

--- a/3.4/slim/Dockerfile
+++ b/3.4/slim/Dockerfile
@@ -24,11 +24,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.4.6
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-ENV PYTHON_SETUPTOOLS_VERSION 35.0.2
-ENV PYTHON_WHEEL_VERSION 0.29.0
-
 RUN set -ex \
 	&& buildDeps=' \
 		gcc \
@@ -63,23 +58,12 @@ RUN set -ex \
 	&& ./configure \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
-	&& make -j$(nproc) \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
 	\
-# explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
-	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python3 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-	; fi \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
+	&& apt-get purge -y --auto-remove $buildDeps \
 	\
 	&& find /usr/local -depth \
 		\( \
@@ -87,15 +71,41 @@ RUN set -ex \
 			-o \
 			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		\) -exec rm -rf '{}' + \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python ~/.cache
+	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \
-	&& { [ -e easy_install ] || ln -s easy_install-* easy_install; } \
 	&& ln -s idle3 idle \
 	&& ln -s pydoc3 pydoc \
 	&& ln -s python3 python \
 	&& ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends wget; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	apt-get purge -y --auto-remove wget; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["python3"]

--- a/3.4/wheezy/Dockerfile
+++ b/3.4/wheezy/Dockerfile
@@ -22,11 +22,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.4.6
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-ENV PYTHON_SETUPTOOLS_VERSION 35.0.2
-ENV PYTHON_WHEEL_VERSION 0.29.0
-
 RUN set -ex \
 	&& buildDeps=' \
 		tcl-dev \
@@ -48,23 +43,12 @@ RUN set -ex \
 	&& ./configure \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
-	&& make -j$(nproc) \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
 	\
-# explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
-	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python3 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-	; fi \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
+	&& apt-get purge -y --auto-remove $buildDeps \
 	\
 	&& find /usr/local -depth \
 		\( \
@@ -72,15 +56,35 @@ RUN set -ex \
 			-o \
 			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		\) -exec rm -rf '{}' + \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python ~/.cache
+	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \
-	&& { [ -e easy_install ] || ln -s easy_install-* easy_install; } \
 	&& ln -s idle3 idle \
 	&& ln -s pydoc3 pydoc \
 	&& ln -s python3 python \
 	&& ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN set -ex; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["python3"]

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -22,11 +22,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.5.3
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-ENV PYTHON_SETUPTOOLS_VERSION 35.0.2
-ENV PYTHON_WHEEL_VERSION 0.29.0
-
 RUN set -ex \
 	&& buildDeps=' \
 		tcl-dev \
@@ -48,23 +43,12 @@ RUN set -ex \
 	&& ./configure \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
-	&& make -j$(nproc) \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
 	\
-# explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
-	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python3 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-	; fi \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
+	&& apt-get purge -y --auto-remove $buildDeps \
 	\
 	&& find /usr/local -depth \
 		\( \
@@ -72,15 +56,35 @@ RUN set -ex \
 			-o \
 			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		\) -exec rm -rf '{}' + \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python ~/.cache
+	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \
-	&& { [ -e easy_install ] || ln -s easy_install-* easy_install; } \
 	&& ln -s idle3 idle \
 	&& ln -s pydoc3 pydoc \
 	&& ln -s python3 python \
 	&& ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN set -ex; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["python3"]

--- a/3.5/alpine/Dockerfile
+++ b/3.5/alpine/Dockerfile
@@ -20,11 +20,6 @@ RUN apk add --no-cache ca-certificates
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.5.3
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-ENV PYTHON_SETUPTOOLS_VERSION 35.0.2
-ENV PYTHON_WHEEL_VERSION 0.29.0
-
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
@@ -67,29 +62,10 @@ RUN set -ex \
 	&& ./configure \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
-	&& make -j$(getconf _NPROCESSORS_ONLN) \
+		--without-ensurepip \
+	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
 	&& make install \
 	\
-# explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
-	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python3 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-	; fi \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
-	\
-	&& find /usr/local -depth \
-		\( \
-			\( -type d -a -name test -o -name tests \) \
-			-o \
-			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-		\) -exec rm -rf '{}' + \
 	&& runDeps="$( \
 		scanelf --needed --nobanner --recursive /usr/local \
 			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
@@ -99,14 +75,46 @@ RUN set -ex \
 	)" \
 	&& apk add --virtual .python-rundeps $runDeps \
 	&& apk del .build-deps \
-	&& rm -rf /usr/src/python ~/.cache
+	\
+	&& find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' + \
+	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \
-	&& { [ -e easy_install ] || ln -s easy_install-* easy_install; } \
 	&& ln -s idle3 idle \
 	&& ln -s pydoc3 pydoc \
 	&& ln -s python3 python \
 	&& ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN set -ex; \
+	\
+	apk add --no-cache --virtual .fetch-deps openssl; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	apk del .fetch-deps; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["python3"]

--- a/3.5/slim/Dockerfile
+++ b/3.5/slim/Dockerfile
@@ -24,11 +24,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.5.3
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-ENV PYTHON_SETUPTOOLS_VERSION 35.0.2
-ENV PYTHON_WHEEL_VERSION 0.29.0
-
 RUN set -ex \
 	&& buildDeps=' \
 		gcc \
@@ -63,23 +58,12 @@ RUN set -ex \
 	&& ./configure \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
-	&& make -j$(nproc) \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
 	\
-# explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
-	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python3 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-	; fi \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
+	&& apt-get purge -y --auto-remove $buildDeps \
 	\
 	&& find /usr/local -depth \
 		\( \
@@ -87,15 +71,41 @@ RUN set -ex \
 			-o \
 			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		\) -exec rm -rf '{}' + \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python ~/.cache
+	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \
-	&& { [ -e easy_install ] || ln -s easy_install-* easy_install; } \
 	&& ln -s idle3 idle \
 	&& ln -s pydoc3 pydoc \
 	&& ln -s python3 python \
 	&& ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends wget; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	apt-get purge -y --auto-remove wget; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["python3"]

--- a/3.5/windows/windowsservercore/Dockerfile
+++ b/3.5/windows/windowsservercore/Dockerfile
@@ -11,11 +11,6 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 ENV PYTHON_VERSION 3.5.3
 ENV PYTHON_RELEASE 3.5.3
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-ENV PYTHON_SETUPTOOLS_VERSION 35.0.2
-ENV PYTHON_WHEEL_VERSION 0.29.0
-
 RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env:PYTHON_RELEASE, $env:PYTHON_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	(New-Object System.Net.WebClient).DownloadFile($url, 'python.exe'); \
@@ -30,6 +25,7 @@ RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env
 			'PrependPath=1', \
 			'Shortcuts=0', \
 			'Include_doc=0', \
+			'Include_pip=0', \
 			'Include_test=0' \
 		); \
 	\
@@ -42,16 +38,19 @@ RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env
 	Write-Host 'Removing ...'; \
 	Remove-Item python.exe -Force; \
 	\
-	Write-Host ('Installing pip=={0} ...' -f $env:PYTHON_PIP_VERSION); \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-# (using "python -m pip" instead of "pip" to avoid pip trying to remove itself while it's running; see also https://pip.readthedocs.io/en/stable/installing/#id6)
-	python -m pip install --no-cache-dir --upgrade --force-reinstall \
+	Write-Host 'Complete.';
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN Write-Host ('Installing pip=={0} ...' -f $env:PYTHON_PIP_VERSION); \
+	(New-Object System.Net.WebClient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', 'get-pip.py'); \
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
 		('pip=={0}' -f $env:PYTHON_PIP_VERSION) \
-		('setuptools=={0}' -f $env:PYTHON_SETUPTOOLS_VERSION) \
-		('wheel=={0}' -f $env:PYTHON_WHEEL_VERSION) \
 	; \
+	Remove-Item get-pip.py -Force; \
 	\
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -22,11 +22,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.6.1
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-ENV PYTHON_SETUPTOOLS_VERSION 35.0.2
-ENV PYTHON_WHEEL_VERSION 0.29.0
-
 RUN set -ex \
 	&& buildDeps=' \
 		tcl-dev \
@@ -48,23 +43,12 @@ RUN set -ex \
 	&& ./configure \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
-	&& make -j$(nproc) \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
 	\
-# explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
-	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python3 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-	; fi \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
+	&& apt-get purge -y --auto-remove $buildDeps \
 	\
 	&& find /usr/local -depth \
 		\( \
@@ -72,15 +56,35 @@ RUN set -ex \
 			-o \
 			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		\) -exec rm -rf '{}' + \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python ~/.cache
+	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \
-	&& { [ -e easy_install ] || ln -s easy_install-* easy_install; } \
 	&& ln -s idle3 idle \
 	&& ln -s pydoc3 pydoc \
 	&& ln -s python3 python \
 	&& ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN set -ex; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["python3"]

--- a/3.6/alpine/Dockerfile
+++ b/3.6/alpine/Dockerfile
@@ -20,11 +20,6 @@ RUN apk add --no-cache ca-certificates
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.6.1
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-ENV PYTHON_SETUPTOOLS_VERSION 35.0.2
-ENV PYTHON_WHEEL_VERSION 0.29.0
-
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
@@ -67,29 +62,10 @@ RUN set -ex \
 	&& ./configure \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
-	&& make -j$(getconf _NPROCESSORS_ONLN) \
+		--without-ensurepip \
+	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
 	&& make install \
 	\
-# explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
-	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python3 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-	; fi \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
-	\
-	&& find /usr/local -depth \
-		\( \
-			\( -type d -a -name test -o -name tests \) \
-			-o \
-			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-		\) -exec rm -rf '{}' + \
 	&& runDeps="$( \
 		scanelf --needed --nobanner --recursive /usr/local \
 			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
@@ -99,14 +75,46 @@ RUN set -ex \
 	)" \
 	&& apk add --virtual .python-rundeps $runDeps \
 	&& apk del .build-deps \
-	&& rm -rf /usr/src/python ~/.cache
+	\
+	&& find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' + \
+	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \
-	&& { [ -e easy_install ] || ln -s easy_install-* easy_install; } \
 	&& ln -s idle3 idle \
 	&& ln -s pydoc3 pydoc \
 	&& ln -s python3 python \
 	&& ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN set -ex; \
+	\
+	apk add --no-cache --virtual .fetch-deps openssl; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	apk del .fetch-deps; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["python3"]

--- a/3.6/slim/Dockerfile
+++ b/3.6/slim/Dockerfile
@@ -24,11 +24,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.6.1
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-ENV PYTHON_SETUPTOOLS_VERSION 35.0.2
-ENV PYTHON_WHEEL_VERSION 0.29.0
-
 RUN set -ex \
 	&& buildDeps=' \
 		gcc \
@@ -63,23 +58,12 @@ RUN set -ex \
 	&& ./configure \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
-	&& make -j$(nproc) \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
 	\
-# explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
-	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python3 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-	; fi \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
+	&& apt-get purge -y --auto-remove $buildDeps \
 	\
 	&& find /usr/local -depth \
 		\( \
@@ -87,15 +71,41 @@ RUN set -ex \
 			-o \
 			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		\) -exec rm -rf '{}' + \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python ~/.cache
+	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \
-	&& { [ -e easy_install ] || ln -s easy_install-* easy_install; } \
 	&& ln -s idle3 idle \
 	&& ln -s pydoc3 pydoc \
 	&& ln -s python3 python \
 	&& ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends wget; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	apt-get purge -y --auto-remove wget; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["python3"]

--- a/3.6/windows/windowsservercore/Dockerfile
+++ b/3.6/windows/windowsservercore/Dockerfile
@@ -11,11 +11,6 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 ENV PYTHON_VERSION 3.6.1
 ENV PYTHON_RELEASE 3.6.1
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 9.0.1
-ENV PYTHON_SETUPTOOLS_VERSION 35.0.2
-ENV PYTHON_WHEEL_VERSION 0.29.0
-
 RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env:PYTHON_RELEASE, $env:PYTHON_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	(New-Object System.Net.WebClient).DownloadFile($url, 'python.exe'); \
@@ -30,6 +25,7 @@ RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env
 			'PrependPath=1', \
 			'Shortcuts=0', \
 			'Include_doc=0', \
+			'Include_pip=0', \
 			'Include_test=0' \
 		); \
 	\
@@ -42,16 +38,19 @@ RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env
 	Write-Host 'Removing ...'; \
 	Remove-Item python.exe -Force; \
 	\
-	Write-Host ('Installing pip=={0} ...' -f $env:PYTHON_PIP_VERSION); \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-# (using "python -m pip" instead of "pip" to avoid pip trying to remove itself while it's running; see also https://pip.readthedocs.io/en/stable/installing/#id6)
-	python -m pip install --no-cache-dir --upgrade --force-reinstall \
+	Write-Host 'Complete.';
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN Write-Host ('Installing pip=={0} ...' -f $env:PYTHON_PIP_VERSION); \
+	(New-Object System.Net.WebClient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', 'get-pip.py'); \
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
 		('pip=={0}' -f $env:PYTHON_PIP_VERSION) \
-		('setuptools=={0}' -f $env:PYTHON_SETUPTOOLS_VERSION) \
-		('wheel=={0}' -f $env:PYTHON_WHEEL_VERSION) \
 	; \
+	Remove-Item get-pip.py -Force; \
 	\
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -14,11 +14,6 @@ RUN apk add --no-cache ca-certificates
 ENV GPG_KEY %%PLACEHOLDER%%
 ENV PYTHON_VERSION %%PLACEHOLDER%%
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION %%PLACEHOLDER%%
-ENV PYTHON_SETUPTOOLS_VERSION %%PLACEHOLDER%%
-ENV PYTHON_WHEEL_VERSION %%PLACEHOLDER%%
-
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
@@ -61,29 +56,10 @@ RUN set -ex \
 	&& ./configure \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
-	&& make -j$(getconf _NPROCESSORS_ONLN) \
+		--without-ensurepip \
+	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
 	&& make install \
 	\
-# explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
-	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python3 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-	; fi \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
-	\
-	&& find /usr/local -depth \
-		\( \
-			\( -type d -a -name test -o -name tests \) \
-			-o \
-			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-		\) -exec rm -rf '{}' + \
 	&& runDeps="$( \
 		scanelf --needed --nobanner --recursive /usr/local \
 			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
@@ -93,14 +69,46 @@ RUN set -ex \
 	)" \
 	&& apk add --virtual .python-rundeps $runDeps \
 	&& apk del .build-deps \
-	&& rm -rf /usr/src/python ~/.cache
+	\
+	&& find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' + \
+	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \
-	&& { [ -e easy_install ] || ln -s easy_install-* easy_install; } \
 	&& ln -s idle3 idle \
 	&& ln -s pydoc3 pydoc \
 	&& ln -s python3 python \
 	&& ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION %%PLACEHOLDER%%
+
+RUN set -ex; \
+	\
+	apk add --no-cache --virtual .fetch-deps openssl; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	apk del .fetch-deps; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["python3"]

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -16,11 +16,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV GPG_KEY %%PLACEHOLDER%%
 ENV PYTHON_VERSION %%PLACEHOLDER%%
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION %%PLACEHOLDER%%
-ENV PYTHON_SETUPTOOLS_VERSION %%PLACEHOLDER%%
-ENV PYTHON_WHEEL_VERSION %%PLACEHOLDER%%
-
 RUN set -ex \
 	&& buildDeps=' \
 		tcl-dev \
@@ -42,23 +37,12 @@ RUN set -ex \
 	&& ./configure \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
-	&& make -j$(nproc) \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
 	\
-# explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
-	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python3 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-	; fi \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
+	&& apt-get purge -y --auto-remove $buildDeps \
 	\
 	&& find /usr/local -depth \
 		\( \
@@ -66,15 +50,35 @@ RUN set -ex \
 			-o \
 			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		\) -exec rm -rf '{}' + \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python ~/.cache
+	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \
-	&& { [ -e easy_install ] || ln -s easy_install-* easy_install; } \
 	&& ln -s idle3 idle \
 	&& ln -s pydoc3 pydoc \
 	&& ln -s python3 python \
 	&& ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION %%PLACEHOLDER%%
+
+RUN set -ex; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["python3"]

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -18,11 +18,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV GPG_KEY %%PLACEHOLDER%%
 ENV PYTHON_VERSION %%PLACEHOLDER%%
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION %%PLACEHOLDER%%
-ENV PYTHON_SETUPTOOLS_VERSION %%PLACEHOLDER%%
-ENV PYTHON_WHEEL_VERSION %%PLACEHOLDER%%
-
 RUN set -ex \
 	&& buildDeps=' \
 		gcc \
@@ -57,23 +52,12 @@ RUN set -ex \
 	&& ./configure \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
-	&& make -j$(nproc) \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
 	\
-# explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
-	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python3 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-	; fi \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-	&& pip3 install --no-cache-dir --upgrade --force-reinstall \
-		"pip==$PYTHON_PIP_VERSION" \
-		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-		"wheel==$PYTHON_WHEEL_VERSION" \
+	&& apt-get purge -y --auto-remove $buildDeps \
 	\
 	&& find /usr/local -depth \
 		\( \
@@ -81,15 +65,41 @@ RUN set -ex \
 			-o \
 			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 		\) -exec rm -rf '{}' + \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python ~/.cache
+	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \
-	&& { [ -e easy_install ] || ln -s easy_install-* easy_install; } \
 	&& ln -s idle3 idle \
 	&& ln -s pydoc3 pydoc \
 	&& ln -s python3 python \
 	&& ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION %%PLACEHOLDER%%
+
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends wget; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	apt-get purge -y --auto-remove wget; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a -name test -o -name tests \) \
+			-o \
+			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["python3"]

--- a/Dockerfile-windowsservercore.template
+++ b/Dockerfile-windowsservercore.template
@@ -5,11 +5,6 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 ENV PYTHON_VERSION %%PLACEHOLDER%%
 ENV PYTHON_RELEASE %%PLACEHOLDER%%
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION %%PLACEHOLDER%%
-ENV PYTHON_SETUPTOOLS_VERSION %%PLACEHOLDER%%
-ENV PYTHON_WHEEL_VERSION %%PLACEHOLDER%%
-
 RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env:PYTHON_RELEASE, $env:PYTHON_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	(New-Object System.Net.WebClient).DownloadFile($url, 'python.exe'); \
@@ -24,6 +19,7 @@ RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env
 			'PrependPath=1', \
 			'Shortcuts=0', \
 			'Include_doc=0', \
+			'Include_pip=0', \
 			'Include_test=0' \
 		); \
 	\
@@ -36,16 +32,19 @@ RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env
 	Write-Host 'Removing ...'; \
 	Remove-Item python.exe -Force; \
 	\
-	Write-Host ('Installing pip=={0} ...' -f $env:PYTHON_PIP_VERSION); \
-# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
-# https://github.com/docker-library/python/pull/143#issuecomment-241032683
-# (using "python -m pip" instead of "pip" to avoid pip trying to remove itself while it's running; see also https://pip.readthedocs.io/en/stable/installing/#id6)
-	python -m pip install --no-cache-dir --upgrade --force-reinstall \
+	Write-Host 'Complete.';
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION %%PLACEHOLDER%%
+
+RUN Write-Host ('Installing pip=={0} ...' -f $env:PYTHON_PIP_VERSION); \
+	(New-Object System.Net.WebClient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', 'get-pip.py'); \
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
 		('pip=={0}' -f $env:PYTHON_PIP_VERSION) \
-		('setuptools=={0}' -f $env:PYTHON_SETUPTOOLS_VERSION) \
-		('wheel=={0}' -f $env:PYTHON_WHEEL_VERSION) \
 	; \
+	Remove-Item get-pip.py -Force; \
 	\
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \

--- a/update.sh
+++ b/update.sh
@@ -33,8 +33,6 @@ fi
 versions=( "${versions[@]%/}" )
 
 pipVersion="$(curl -fsSL 'https://pypi.org/pypi/pip/json' | jq -r .info.version)"
-setuptoolsVersion="$(curl -fsSL 'https://pypi.org/pypi/setuptools/json' | jq -r .info.version)"
-wheelVersion="$(curl -fsSL 'https://pypi.org/pypi/wheel/json' | jq -r .info.version)"
 
 generated_warning() {
 	cat <<-EOH
@@ -106,8 +104,6 @@ for version in "${versions[@]}"; do
 				-e 's/^(ENV PYTHON_VERSION) .*/\1 '"$fullVersion"'/' \
 				-e 's/^(ENV PYTHON_RELEASE) .*/\1 '"${fullVersion%%[a-z]*}"'/' \
 				-e 's/^(ENV PYTHON_PIP_VERSION) .*/\1 '"$pipVersion"'/' \
-				-e 's/^(ENV PYTHON_SETUPTOOLS_VERSION) .*/\1 '"$setuptoolsVersion"'/' \
-				-e 's/^(ENV PYTHON_WHEEL_VERSION) .*/\1 '"$wheelVersion"'/' \
 				-e 's/^(FROM python):.*/\1:'"$version"'/' \
 				"$version"/{,*/,*/*/}Dockerfile
 		)


### PR DESCRIPTION
Combining `--without-ensurepip` / `Include_pip=0` and `get-pip.py`, we can move the `pip` installation to an entirely separate layer, thus allowing for `pip`-only bumps to build faster, given that Python will not also need to be recompiled.  This also insulates us from having to decide how often to bump `setuptools` (which has a fairly aggressive release cycle) -- it will naturally bump to the latest version at every `pip` release, every Python release, or every base-image-triggered rebuild.

See also https://github.com/docker-library/python/pull/186, especially https://github.com/docker-library/python/pull/186#issuecomment-297955361.

Thanks to @mal for bringing the issue up originally (and suggesting pretty much this exact fix in a slightly different form :innocent:), @JayH5 for pointing out how aggressive the `setuptools` release cycle is, and @dstufft for being generally awesome, doing good work, and on top of all that being willing to help point us in sane directions when we're going crazy. :heart: :heart: