### PR TITLE
Add explicit "--build" to our "./configure" invocations

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -18,6 +18,7 @@ ENV PYTHON_VERSION 2.7.13
 
 RUN set -ex \
 	&& buildDeps=' \
+		dpkg-dev \
 		tcl-dev \
 		tk-dev \
 	' \
@@ -34,7 +35,9 @@ RUN set -ex \
 	&& rm python.tar.xz \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-shared \
 		--enable-unicode=ucs4 \
 	&& make -j "$(nproc)" \

--- a/2.7/alpine/Dockerfile
+++ b/2.7/alpine/Dockerfile
@@ -33,6 +33,8 @@ RUN set -ex \
 	\
 	&& apk add --no-cache --virtual .build-deps  \
 		bzip2-dev \
+		coreutils \
+		dpkg-dev dpkg \
 		gcc \
 		gdbm-dev \
 		libc-dev \
@@ -52,10 +54,12 @@ RUN set -ex \
 	&& apk del .fetch-deps \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-shared \
 		--enable-unicode=ucs4 \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& runDeps="$( \

--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -20,6 +20,7 @@ ENV PYTHON_VERSION 2.7.13
 
 RUN set -ex \
 	&& buildDeps=' \
+		dpkg-dev \
 		gcc \
 		libbz2-dev \
 		libc6-dev \
@@ -49,7 +50,9 @@ RUN set -ex \
 	&& rm python.tar.xz \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-shared \
 		--enable-unicode=ucs4 \
 	&& make -j "$(nproc)" \

--- a/2.7/wheezy/Dockerfile
+++ b/2.7/wheezy/Dockerfile
@@ -18,6 +18,7 @@ ENV PYTHON_VERSION 2.7.13
 
 RUN set -ex \
 	&& buildDeps=' \
+		dpkg-dev \
 		tcl-dev \
 		tk-dev \
 	' \
@@ -34,7 +35,9 @@ RUN set -ex \
 	&& rm python.tar.xz \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-shared \
 		--enable-unicode=ucs4 \
 	&& make -j "$(nproc)" \

--- a/2.7/wheezy/Dockerfile
+++ b/2.7/wheezy/Dockerfile
@@ -35,7 +35,7 @@ RUN set -ex \
 	&& rm python.tar.xz \
 	\
 	&& cd /usr/src/python \
-	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& gnuArch="$(dpkg-architecture -qDEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
 		--build="$gnuArch" \
 		--enable-shared \

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -24,6 +24,7 @@ ENV PYTHON_VERSION 3.3.6
 
 RUN set -ex \
 	&& buildDeps=' \
+		dpkg-dev \
 		tcl-dev \
 		tk-dev \
 	' \
@@ -40,7 +41,9 @@ RUN set -ex \
 	&& rm python.tar.xz \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
 		--without-ensurepip \

--- a/3.3/alpine/Dockerfile
+++ b/3.3/alpine/Dockerfile
@@ -39,6 +39,8 @@ RUN set -ex \
 	\
 	&& apk add --no-cache --virtual .build-deps  \
 		bzip2-dev \
+		coreutils \
+		dpkg-dev dpkg \
 		gcc \
 		gdbm-dev \
 		libc-dev \
@@ -59,11 +61,13 @@ RUN set -ex \
 	&& apk del .fetch-deps \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
 		--without-ensurepip \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& runDeps="$( \

--- a/3.3/slim/Dockerfile
+++ b/3.3/slim/Dockerfile
@@ -26,6 +26,7 @@ ENV PYTHON_VERSION 3.3.6
 
 RUN set -ex \
 	&& buildDeps=' \
+		dpkg-dev \
 		gcc \
 		libbz2-dev \
 		libc6-dev \
@@ -55,7 +56,9 @@ RUN set -ex \
 	&& rm python.tar.xz \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
 		--without-ensurepip \

--- a/3.3/wheezy/Dockerfile
+++ b/3.3/wheezy/Dockerfile
@@ -24,6 +24,7 @@ ENV PYTHON_VERSION 3.3.6
 
 RUN set -ex \
 	&& buildDeps=' \
+		dpkg-dev \
 		tcl-dev \
 		tk-dev \
 	' \
@@ -40,7 +41,9 @@ RUN set -ex \
 	&& rm python.tar.xz \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
 		--without-ensurepip \

--- a/3.3/wheezy/Dockerfile
+++ b/3.3/wheezy/Dockerfile
@@ -41,7 +41,7 @@ RUN set -ex \
 	&& rm python.tar.xz \
 	\
 	&& cd /usr/src/python \
-	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& gnuArch="$(dpkg-architecture -qDEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -24,6 +24,7 @@ ENV PYTHON_VERSION 3.4.6
 
 RUN set -ex \
 	&& buildDeps=' \
+		dpkg-dev \
 		tcl-dev \
 		tk-dev \
 	' \
@@ -40,7 +41,9 @@ RUN set -ex \
 	&& rm python.tar.xz \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
 		--without-ensurepip \

--- a/3.4/alpine/Dockerfile
+++ b/3.4/alpine/Dockerfile
@@ -39,6 +39,8 @@ RUN set -ex \
 	\
 	&& apk add --no-cache --virtual .build-deps  \
 		bzip2-dev \
+		coreutils \
+		dpkg-dev dpkg \
 		gcc \
 		gdbm-dev \
 		libc-dev \
@@ -59,11 +61,13 @@ RUN set -ex \
 	&& apk del .fetch-deps \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
 		--without-ensurepip \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& runDeps="$( \

--- a/3.4/slim/Dockerfile
+++ b/3.4/slim/Dockerfile
@@ -26,6 +26,7 @@ ENV PYTHON_VERSION 3.4.6
 
 RUN set -ex \
 	&& buildDeps=' \
+		dpkg-dev \
 		gcc \
 		libbz2-dev \
 		libc6-dev \
@@ -55,7 +56,9 @@ RUN set -ex \
 	&& rm python.tar.xz \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
 		--without-ensurepip \

--- a/3.4/wheezy/Dockerfile
+++ b/3.4/wheezy/Dockerfile
@@ -41,7 +41,7 @@ RUN set -ex \
 	&& rm python.tar.xz \
 	\
 	&& cd /usr/src/python \
-	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& gnuArch="$(dpkg-architecture -qDEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \

--- a/3.4/wheezy/Dockerfile
+++ b/3.4/wheezy/Dockerfile
@@ -24,6 +24,7 @@ ENV PYTHON_VERSION 3.4.6
 
 RUN set -ex \
 	&& buildDeps=' \
+		dpkg-dev \
 		tcl-dev \
 		tk-dev \
 	' \
@@ -40,7 +41,9 @@ RUN set -ex \
 	&& rm python.tar.xz \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
 		--without-ensurepip \

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -24,6 +24,7 @@ ENV PYTHON_VERSION 3.5.3
 
 RUN set -ex \
 	&& buildDeps=' \
+		dpkg-dev \
 		tcl-dev \
 		tk-dev \
 	' \
@@ -40,7 +41,9 @@ RUN set -ex \
 	&& rm python.tar.xz \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
 		--without-ensurepip \

--- a/3.5/alpine/Dockerfile
+++ b/3.5/alpine/Dockerfile
@@ -39,6 +39,8 @@ RUN set -ex \
 	\
 	&& apk add --no-cache --virtual .build-deps  \
 		bzip2-dev \
+		coreutils \
+		dpkg-dev dpkg \
 		gcc \
 		gdbm-dev \
 		libc-dev \
@@ -59,11 +61,13 @@ RUN set -ex \
 	&& apk del .fetch-deps \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
 		--without-ensurepip \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& runDeps="$( \

--- a/3.5/slim/Dockerfile
+++ b/3.5/slim/Dockerfile
@@ -26,6 +26,7 @@ ENV PYTHON_VERSION 3.5.3
 
 RUN set -ex \
 	&& buildDeps=' \
+		dpkg-dev \
 		gcc \
 		libbz2-dev \
 		libc6-dev \
@@ -55,7 +56,9 @@ RUN set -ex \
 	&& rm python.tar.xz \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
 		--without-ensurepip \

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -24,6 +24,7 @@ ENV PYTHON_VERSION 3.6.1
 
 RUN set -ex \
 	&& buildDeps=' \
+		dpkg-dev \
 		tcl-dev \
 		tk-dev \
 	' \
@@ -40,7 +41,9 @@ RUN set -ex \
 	&& rm python.tar.xz \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
 		--without-ensurepip \

--- a/3.6/alpine/Dockerfile
+++ b/3.6/alpine/Dockerfile
@@ -39,6 +39,8 @@ RUN set -ex \
 	\
 	&& apk add --no-cache --virtual .build-deps  \
 		bzip2-dev \
+		coreutils \
+		dpkg-dev dpkg \
 		gcc \
 		gdbm-dev \
 		libc-dev \
@@ -59,11 +61,13 @@ RUN set -ex \
 	&& apk del .fetch-deps \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
 		--without-ensurepip \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& runDeps="$( \

--- a/3.6/slim/Dockerfile
+++ b/3.6/slim/Dockerfile
@@ -26,6 +26,7 @@ ENV PYTHON_VERSION 3.6.1
 
 RUN set -ex \
 	&& buildDeps=' \
+		dpkg-dev \
 		gcc \
 		libbz2-dev \
 		libc6-dev \
@@ -55,7 +56,9 @@ RUN set -ex \
 	&& rm python.tar.xz \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
 		--without-ensurepip \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -33,6 +33,8 @@ RUN set -ex \
 	\
 	&& apk add --no-cache --virtual .build-deps  \
 		bzip2-dev \
+		coreutils \
+		dpkg-dev dpkg \
 		gcc \
 		gdbm-dev \
 		libc-dev \
@@ -53,11 +55,13 @@ RUN set -ex \
 	&& apk del .fetch-deps \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
 		--without-ensurepip \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& runDeps="$( \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -18,6 +18,7 @@ ENV PYTHON_VERSION %%PLACEHOLDER%%
 
 RUN set -ex \
 	&& buildDeps=' \
+		dpkg-dev \
 		tcl-dev \
 		tk-dev \
 	' \
@@ -34,7 +35,9 @@ RUN set -ex \
 	&& rm python.tar.xz \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
 		--without-ensurepip \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -20,6 +20,7 @@ ENV PYTHON_VERSION %%PLACEHOLDER%%
 
 RUN set -ex \
 	&& buildDeps=' \
+		dpkg-dev \
 		gcc \
 		libbz2-dev \
 		libc6-dev \
@@ -49,7 +50,9 @@ RUN set -ex \
 	&& rm python.tar.xz \
 	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
 		--without-ensurepip \

--- a/update.sh
+++ b/update.sh
@@ -94,7 +94,11 @@ for version in "${versions[@]}"; do
 			done
 			if [ -d "$version/wheezy" ]; then
 				cp "$version/Dockerfile" "$version/wheezy/Dockerfile"
-				sed -ri 's/:jessie/:wheezy/g' "$version/wheezy/Dockerfile"
+				# wheezy-only: dpkg-architecture: unknown option `--query'
+				sed -ri \
+					-e 's/:jessie/:wheezy/g' \
+					-e 's/dpkg-architecture --query /dpkg-architecture -q/g' \
+					"$version/wheezy/Dockerfile"
 			fi
 		fi
 		(


### PR DESCRIPTION
This is along the same lines as:

- https://github.com/docker-library/ruby/pull/127
- https://github.com/docker-library/tomcat/pull/70
- https://github.com/docker-library/memcached/pull/13
- https://github.com/tianon/docker-bash/pull/3

```console
+ rm -r /tmp/tmp.XqFDvrXGni python.tar.xz.asc
+ mkdir -p /usr/src/python
+ tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz
+ rm python.tar.xz
+ cd /usr/src/python
+ dpkg-architecture --query DEB_BUILD_GNU_TYPE
+ gnuArch=s390x-linux-gnu
+ ./configure --build=s390x-linux-gnu --enable-shared --enable-unicode=ucs4
checking build system type... s390x-ibm-linux-gnu
checking host system type... s390x-ibm-linux-gnu
checking for --enable-universalsdk... no
checking for --with-universal-archs... 32-bit
checking MACHDEP... linux2
checking EXTRAPLATDIR... 
checking for --without-gcc... no
checking for --with-icc... no
checking for gcc... gcc
```