### PR TITLE
Fix _ctypes test failure on Alpine and build failure on Debian on ppc64le

### DIFF
--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -46,6 +46,8 @@ RUN set -ex \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
 		--without-ensurepip \
 	&& make -j "$(nproc)" \
 	&& make install \

--- a/3.3/alpine/Dockerfile
+++ b/3.3/alpine/Dockerfile
@@ -41,9 +41,11 @@ RUN set -ex \
 		bzip2-dev \
 		coreutils \
 		dpkg-dev dpkg \
+		expat-dev \
 		gcc \
 		gdbm-dev \
 		libc-dev \
+		libffi-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
@@ -66,6 +68,8 @@ RUN set -ex \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
 		--without-ensurepip \
 	&& make -j "$(nproc)" \
 	&& make install \

--- a/3.3/slim/Dockerfile
+++ b/3.3/slim/Dockerfile
@@ -16,6 +16,8 @@ ENV LANG C.UTF-8
 # runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
+		libexpat1 \
+		libffi6 \
 		libgdbm3 \
 		libsqlite3-0 \
 		libssl1.0.0 \
@@ -30,6 +32,8 @@ RUN set -ex \
 		gcc \
 		libbz2-dev \
 		libc6-dev \
+		libexpat1-dev \
+		libffi-dev \
 		libgdbm-dev \
 		liblzma-dev \
 		libncurses-dev \
@@ -61,6 +65,8 @@ RUN set -ex \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
 		--without-ensurepip \
 	&& make -j "$(nproc)" \
 	&& make install \

--- a/3.3/wheezy/Dockerfile
+++ b/3.3/wheezy/Dockerfile
@@ -46,6 +46,8 @@ RUN set -ex \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
 		--without-ensurepip \
 	&& make -j "$(nproc)" \
 	&& make install \

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -46,6 +46,8 @@ RUN set -ex \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
 		--without-ensurepip \
 	&& make -j "$(nproc)" \
 	&& make install \

--- a/3.4/alpine/Dockerfile
+++ b/3.4/alpine/Dockerfile
@@ -41,9 +41,11 @@ RUN set -ex \
 		bzip2-dev \
 		coreutils \
 		dpkg-dev dpkg \
+		expat-dev \
 		gcc \
 		gdbm-dev \
 		libc-dev \
+		libffi-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
@@ -66,6 +68,8 @@ RUN set -ex \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
 		--without-ensurepip \
 	&& make -j "$(nproc)" \
 	&& make install \

--- a/3.4/slim/Dockerfile
+++ b/3.4/slim/Dockerfile
@@ -16,6 +16,8 @@ ENV LANG C.UTF-8
 # runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
+		libexpat1 \
+		libffi6 \
 		libgdbm3 \
 		libsqlite3-0 \
 		libssl1.0.0 \
@@ -30,6 +32,8 @@ RUN set -ex \
 		gcc \
 		libbz2-dev \
 		libc6-dev \
+		libexpat1-dev \
+		libffi-dev \
 		libgdbm-dev \
 		liblzma-dev \
 		libncurses-dev \
@@ -61,6 +65,8 @@ RUN set -ex \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
 		--without-ensurepip \
 	&& make -j "$(nproc)" \
 	&& make install \

--- a/3.4/wheezy/Dockerfile
+++ b/3.4/wheezy/Dockerfile
@@ -46,6 +46,8 @@ RUN set -ex \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
 		--without-ensurepip \
 	&& make -j "$(nproc)" \
 	&& make install \

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -46,6 +46,8 @@ RUN set -ex \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
 		--without-ensurepip \
 	&& make -j "$(nproc)" \
 	&& make install \

--- a/3.5/alpine/Dockerfile
+++ b/3.5/alpine/Dockerfile
@@ -41,9 +41,11 @@ RUN set -ex \
 		bzip2-dev \
 		coreutils \
 		dpkg-dev dpkg \
+		expat-dev \
 		gcc \
 		gdbm-dev \
 		libc-dev \
+		libffi-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
@@ -66,6 +68,8 @@ RUN set -ex \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
 		--without-ensurepip \
 	&& make -j "$(nproc)" \
 	&& make install \

--- a/3.5/slim/Dockerfile
+++ b/3.5/slim/Dockerfile
@@ -16,6 +16,8 @@ ENV LANG C.UTF-8
 # runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
+		libexpat1 \
+		libffi6 \
 		libgdbm3 \
 		libsqlite3-0 \
 		libssl1.0.0 \
@@ -30,6 +32,8 @@ RUN set -ex \
 		gcc \
 		libbz2-dev \
 		libc6-dev \
+		libexpat1-dev \
+		libffi-dev \
 		libgdbm-dev \
 		liblzma-dev \
 		libncurses-dev \
@@ -61,6 +65,8 @@ RUN set -ex \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
 		--without-ensurepip \
 	&& make -j "$(nproc)" \
 	&& make install \

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -46,6 +46,8 @@ RUN set -ex \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
 		--without-ensurepip \
 	&& make -j "$(nproc)" \
 	&& make install \

--- a/3.6/alpine/Dockerfile
+++ b/3.6/alpine/Dockerfile
@@ -41,9 +41,11 @@ RUN set -ex \
 		bzip2-dev \
 		coreutils \
 		dpkg-dev dpkg \
+		expat-dev \
 		gcc \
 		gdbm-dev \
 		libc-dev \
+		libffi-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
@@ -66,6 +68,8 @@ RUN set -ex \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
 		--without-ensurepip \
 	&& make -j "$(nproc)" \
 	&& make install \

--- a/3.6/alpine3.6/Dockerfile
+++ b/3.6/alpine3.6/Dockerfile
@@ -41,9 +41,11 @@ RUN set -ex \
 		bzip2-dev \
 		coreutils \
 		dpkg-dev dpkg \
+		expat-dev \
 		gcc \
 		gdbm-dev \
 		libc-dev \
+		libffi-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
@@ -66,6 +68,8 @@ RUN set -ex \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
 		--without-ensurepip \
 	&& make -j "$(nproc)" \
 	&& make install \

--- a/3.6/slim/Dockerfile
+++ b/3.6/slim/Dockerfile
@@ -16,6 +16,8 @@ ENV LANG C.UTF-8
 # runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
+		libexpat1 \
+		libffi6 \
 		libgdbm3 \
 		libsqlite3-0 \
 		libssl1.0.0 \
@@ -30,6 +32,8 @@ RUN set -ex \
 		gcc \
 		libbz2-dev \
 		libc6-dev \
+		libexpat1-dev \
+		libffi-dev \
 		libgdbm-dev \
 		liblzma-dev \
 		libncurses-dev \
@@ -61,6 +65,8 @@ RUN set -ex \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
 		--without-ensurepip \
 	&& make -j "$(nproc)" \
 	&& make install \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -35,9 +35,11 @@ RUN set -ex \
 		bzip2-dev \
 		coreutils \
 		dpkg-dev dpkg \
+		expat-dev \
 		gcc \
 		gdbm-dev \
 		libc-dev \
+		libffi-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
@@ -60,6 +62,8 @@ RUN set -ex \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
 		--without-ensurepip \
 	&& make -j "$(nproc)" \
 	&& make install \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -40,6 +40,8 @@ RUN set -ex \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
 		--without-ensurepip \
 	&& make -j "$(nproc)" \
 	&& make install \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -10,6 +10,8 @@ ENV LANG C.UTF-8
 # runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
+		libexpat1 \
+		libffi6 \
 		libgdbm3 \
 		libsqlite3-0 \
 		libssl1.0.0 \
@@ -24,6 +26,8 @@ RUN set -ex \
 		gcc \
 		libbz2-dev \
 		libc6-dev \
+		libexpat1-dev \
+		libffi-dev \
 		libgdbm-dev \
 		liblzma-dev \
 		libncurses-dev \
@@ -55,6 +59,8 @@ RUN set -ex \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
 		--without-ensurepip \
 	&& make -j "$(nproc)" \
 	&& make install \


### PR DESCRIPTION
replaces/closes #190.

@elbaschid, sorry to replace your PR, I was working on multi-arch images and found out that this fixes the build for ppc64le (https://bugs.python.org/issue22157), so I applied it to all the versions of python 3.

This might fix the build failure on [arm64v8](https://doi-janky.infosiftr.net/job/multiarch/view/all-images/view/python/job/arm64v8/job/python/1/console), but I haven't tested it there yet.