### PR TITLE
Remove support for arm32v5 (takes days to build)

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -134,6 +134,9 @@ for version in "${versions[@]}"; do
 				;;
 		esac
 
+		# arm32v5 takes _way_ too long to build (on the order of days)
+		variantArches="$(echo " $variantArches " | sed -r -e 's/ arm32v5//g')"
+
 		echo
 		cat <<-EOE
 			Tags: $(join ', ' "${variantAliases[@]}")


### PR DESCRIPTION
See also https://github.com/docker-library/ruby/pull/151.