### PR TITLE
Fix onbuild FROM values

### DIFF
--- a/2.7/jessie/onbuild/Dockerfile
+++ b/2.7/jessie/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:2.7-jessie
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/3.3/jessie/onbuild/Dockerfile
+++ b/3.3/jessie/onbuild/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM python:3.3
+FROM python:3.3-jessie
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/3.4/jessie/onbuild/Dockerfile
+++ b/3.4/jessie/onbuild/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM python:3.4
+FROM python:3.4-jessie
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/3.5/jessie/onbuild/Dockerfile
+++ b/3.5/jessie/onbuild/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM python:3.5
+FROM python:3.5-jessie
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/3.6/jessie/onbuild/Dockerfile
+++ b/3.6/jessie/onbuild/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM python:3.6
+FROM python:3.6-jessie
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/update.sh
+++ b/update.sh
@@ -128,7 +128,7 @@ for version in "${versions[@]}"; do
 			-e 's/^(ENV PYTHON_VERSION) .*/\1 '"$fullVersion"'/' \
 			-e 's/^(ENV PYTHON_RELEASE) .*/\1 '"${fullVersion%%[a-z]*}"'/' \
 			-e 's/^(ENV PYTHON_PIP_VERSION) .*/\1 '"$pipVersion"'/' \
-			-e 's/^(FROM python):.*/\1:'"$version"'/' \
+			-e 's/^(FROM python):.*/\1:'"$version-$tag"'/' \
 			-e 's/^(FROM (debian|buildpack-deps|alpine)):.*/\1:'"$tag"'/' \
 			"$dir/Dockerfile"
 


### PR DESCRIPTION
The tags these are currently referring to are now `SharedTags`, which `bashbrew` doesn't (yet?) use for dependency resolution/calculation (or tagging during `bashbrew build` -- only `bashbrew put-shared`).