### PR TITLE
Copy `python-gdb.py` to /usr/lib/debug to enable use with gdb

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -86,6 +86,7 @@ RUN set -ex \
 			-o \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' + \
+	&& cp /usr/src/python/python-gdb.py /usr/lib/debug/usr/local/bin/python$(echo "${PYTHON_VERSION}" | cut -d'.' -f1,2)-gdb.py \
 	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -55,6 +55,7 @@ RUN set -ex \
 			-o \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' + \
+	&& cp /usr/src/python/python-gdb.py /usr/lib/debug/usr/local/bin/python$(echo "${PYTHON_VERSION}" | cut -d'.' -f1,2)-gdb.py \
 	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -77,6 +77,7 @@ RUN set -ex \
 			-o \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' + \
+	&& cp /usr/src/python/python-gdb.py /usr/lib/debug/usr/local/bin/python$(echo "${PYTHON_VERSION}" | cut -d'.' -f1,2)-gdb.py \
 	&& rm -rf /usr/src/python
 
 # make some useful symlinks that are expected to exist


### PR DESCRIPTION
This is PR for https://github.com/docker-library/python/issues/89

When you want to use GDB with python docker images you have to create your own, because official does not have/support `python-gdb` script, it is removed during build time of image.

This PR proproses to copy it to `/usr/lib/debug/...`  which is in `auto-load` safe path. This enables to use commands like `py-bt` and others in GDB.

Note that to use GDB with `attach` you have to add `SYS_PTRACE` capability to container and even compile your own GDB against python source / library.

Closes #89