### PR TITLE
Alpine: Add libs for nis module (Alpine 3.7/Python 3.7 only)

### DIFF
--- a/3.7-rc/alpine3.7/Dockerfile
+++ b/3.7-rc/alpine3.7/Dockerfile
@@ -46,6 +46,8 @@ RUN set -ex \
 		gdbm-dev \
 		libc-dev \
 		libffi-dev \
+		libnsl-dev \
+		libtirpc-dev \
 		linux-headers \
 		make \
 		ncurses-dev \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -40,6 +40,8 @@ RUN set -ex \
 		gdbm-dev \
 		libc-dev \
 		libffi-dev \
+		libnsl-dev \
+		libtirpc-dev \
 		linux-headers \
 		make \
 		ncurses-dev \

--- a/update.sh
+++ b/update.sh
@@ -158,6 +158,13 @@ for version in "${versions[@]}"; do
 			sed -ri -e 's/libressl/openssl/g' "$dir/Dockerfile"
 		fi
 
+		# Libraries to build the nis module available in Alpine 3.7, but also require this patch:
+		# https://bugs.python.org/issue32521
+		# TODO: Remove Python version check once 2.7 and 3.6 have the patch
+		if [[ "$variant" == alpine* ]] && [[ "$variant" != alpine3.7 || "$version" != 3.7* ]]; then
+			sed -ri -e '/libnsl-dev/d' -e '/libtirpc-dev/d' "$dir/Dockerfile"
+		fi
+
 		case "$v" in
 			wheezy/slim|jessie/slim)
 				sed -ri \


### PR DESCRIPTION
~~Bump Python 3.7 to 3.7.0b2~~

This kind of fixes #247, at least as best as is reasonably possible before Python 3.6.5/2.7.15.

The `nis` module is pretty obscure and I don't personally have a use for it, but it is the one and only optional module that wasn't building on Alpine. This adds ~2MB to the uncompressed image size:
```
REPOSITORY          TAG                        IMAGE ID            CREATED             SIZE
python              3.7.0b2-alpine3.7-no-nis   4ecaf70911d4        11 minutes ago      91.3MB
python              3.7.0b2-alpine3.7          902c6083404d        11 hours ago        93.6MB
```