### PR TITLE
3.6/alpine3.7: Build nis module now that 3.6.5 is patched

### DIFF
--- a/3.6/alpine3.7/Dockerfile
+++ b/3.6/alpine3.7/Dockerfile
@@ -46,6 +46,8 @@ RUN set -ex \
 		gdbm-dev \
 		libc-dev \
 		libffi-dev \
+		libnsl-dev \
+		libtirpc-dev \
 		linux-headers \
 		make \
 		ncurses-dev \

--- a/update.sh
+++ b/update.sh
@@ -160,8 +160,7 @@ for version in "${versions[@]}"; do
 
 		# Libraries to build the nis module available in Alpine 3.7, but also require this patch:
 		# https://bugs.python.org/issue32521
-		# TODO: Remove Python version check once 2.7 and 3.6 have the patch
-		if [[ "$variant" == alpine* ]] && [[ "$variant" != alpine3.7 || "$version" != 3.7* ]]; then
+		if [[ "$variant" == alpine* ]] && [[ "$variant" != alpine3.7 ]]; then
 			sed -ri -e '/libnsl-dev/d' -e '/libtirpc-dev/d' "$dir/Dockerfile"
 		fi
 


### PR DESCRIPTION
Continuation of #266.

Note also there's a Python 3.7.0b3 out now...~~guess the bot hasn't got to it yet.~~