### PR TITLE
Added support for nanoserver based windows containers

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,8 @@ environment:
       variant: windowsservercore-ltsc2016
     - version: 3.6
       variant: windowsservercore-ltsc2016
+    - version: 3.6
+      variant: nanoserver-sac2016
     - version: 2.7
       variant: windowsservercore-ltsc2016
 

--- a/3.6/windows/nanoserver-1709/Dockerfile
+++ b/3.6/windows/nanoserver-1709/Dockerfile
@@ -1,9 +1,15 @@
-FROM microsoft/windowsservercore:%%PLACEHOLDER%% as base
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM microsoft/windowsservercore:1709 as base
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV PYTHON_VERSION %%PLACEHOLDER%%
-ENV PYTHON_RELEASE %%PLACEHOLDER%%
+ENV PYTHON_VERSION 3.6.5
+ENV PYTHON_RELEASE 3.6.5
 
 RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env:PYTHON_RELEASE, $env:PYTHON_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
@@ -35,7 +41,7 @@ RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env
 	Write-Host 'Complete.';
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION %%PLACEHOLDER%%
+ENV PYTHON_PIP_VERSION 9.0.3
 
 RUN Write-Host ('Installing pip=={0} ...' -f $env:PYTHON_PIP_VERSION); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -52,7 +58,7 @@ RUN Write-Host ('Installing pip=={0} ...' -f $env:PYTHON_PIP_VERSION); \
 	\
 	Write-Host 'Complete.';
 
-FROM microsoft/nanoserver:%%PLACEHOLDER%%
+FROM microsoft/nanoserver:1709
 
 COPY --from=base ["Python", "Python"]
 

--- a/3.6/windows/nanoserver-sac2016/Dockerfile
+++ b/3.6/windows/nanoserver-sac2016/Dockerfile
@@ -1,9 +1,15 @@
-FROM microsoft/windowsservercore:%%PLACEHOLDER%% as base
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM microsoft/windowsservercore:sac2016 as base
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV PYTHON_VERSION %%PLACEHOLDER%%
-ENV PYTHON_RELEASE %%PLACEHOLDER%%
+ENV PYTHON_VERSION 3.6.5
+ENV PYTHON_RELEASE 3.6.5
 
 RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env:PYTHON_RELEASE, $env:PYTHON_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
@@ -35,7 +41,7 @@ RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env
 	Write-Host 'Complete.';
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION %%PLACEHOLDER%%
+ENV PYTHON_PIP_VERSION 9.0.3
 
 RUN Write-Host ('Installing pip=={0} ...' -f $env:PYTHON_PIP_VERSION); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -52,7 +58,7 @@ RUN Write-Host ('Installing pip=={0} ...' -f $env:PYTHON_PIP_VERSION); \
 	\
 	Write-Host 'Complete.';
 
-FROM microsoft/nanoserver:%%PLACEHOLDER%%
+FROM microsoft/nanoserver:sac2016
 
 COPY --from=base ["Python", "Python"]
 

--- a/Dockerfile-nanoserver.template
+++ b/Dockerfile-nanoserver.template
@@ -1,0 +1,63 @@
+FROM microsoft/nanoserver:%%PLACEHOLDER%%
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV PYTHON_VERSION %%PLACEHOLDER%%
+ENV PYTHON_RELEASE %%PLACEHOLDER%%
+
+RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env:PYTHON_RELEASE, $env:PYTHON_VERSION); \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	Invoke-WebRequest -Uri $url -OutFile 'python.exe'; \
+	\
+	Write-Host 'Installing ...'; \
+# https://docs.python.org/3.5/using/windows.html#installing-without-ui
+	Start-Process python.exe -Wait \
+		-ArgumentList @( \
+			'/quiet', \
+			'InstallAllUsers=1', \
+			'TargetDir=C:\Python', \
+			'PrependPath=1', \
+			'Shortcuts=0', \
+			'Include_doc=0', \
+			'Include_pip=0', \
+			'Include_test=0' \
+		); \
+	\
+# the installer updated PATH, so we should refresh our local value
+	$env:PATH = [Environment]::GetEnvironmentVariable('PATH', [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  python --version'; python --version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item python.exe -Force; \
+	\
+	Write-Host 'Complete.';
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION %%PLACEHOLDER%%
+
+RUN Write-Host ('Installing pip=={0} ...' -f $env:PYTHON_PIP_VERSION); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri 'https://bootstrap.pypa.io/get-pip.py' -OutFile 'get-pip.py'; \
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		('pip=={0}' -f $env:PYTHON_PIP_VERSION) \
+	; \
+	Remove-Item get-pip.py -Force; \
+	\
+	Write-Host 'Verifying pip install ...'; \
+	pip --version; \
+	\
+	Write-Host 'Complete.';
+
+FROM microsoft/nanoserver:%%PLACEHOLDER%%
+
+COPY --from=base ["Python", "Python"]
+
+USER ContainerAdministrator
+RUN setx /M PATH %PATH%;c:\Python\;c:\Python\scripts\;
+USER ContainerUser
+
+CMD ["python"]

--- a/update.sh
+++ b/update.sh
@@ -123,6 +123,7 @@ for version in "${versions[@]}"; do
 		case "$variant" in
 			slim|onbuild) template="$variant"; tag="$(basename "$(dirname "$dir")")" ;;
 			windowsservercore-*) template='windowsservercore'; tag="${variant#*-}" ;;
+			nanoserver-*) template='nanoserver'; tag="${variant#*-}" ;;
 			alpine*) template='alpine'; tag="${variant#alpine}" ;;
 			*) template='debian'; tag="$variant" ;;
 		esac
@@ -144,7 +145,7 @@ for version in "${versions[@]}"; do
 			-e 's/^(ENV PYTHON_RELEASE) .*/\1 '"${fullVersion%%[a-z]*}"'/' \
 			-e 's/^(ENV PYTHON_PIP_VERSION) .*/\1 '"$pipVersion"'/' \
 			-e 's/^(FROM python):.*/\1:'"$version-$tag"'/' \
-			-e 's!^(FROM (debian|buildpack-deps|alpine|microsoft/[^:]+)):.*!\1:'"$tag"'!' \
+			-e 's!^(FROM (debian|buildpack-deps|alpine|microsoft/[^:]+)):\S*!\1:'"$tag"'!' \
 			"$dir/Dockerfile"
 
 		case "$variant" in


### PR DESCRIPTION
Nanoserver has a much smaller footprint than window server core which make it a great option for any IoT scenario but also perfect anytime a full Windows Server core image is really not needed