### PR TITLE
Python.org also now needs tls 1.2

### DIFF
--- a/2.7/windows/windowsservercore-1709/Dockerfile
+++ b/2.7/windows/windowsservercore-1709/Dockerfile
@@ -7,6 +7,7 @@ ENV PYTHON_RELEASE 2.7.14
 
 RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}.amd64.msi' -f $env:PYTHON_RELEASE, $env:PYTHON_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'python.msi'; \
 	\
 	Write-Host 'Installing ...'; \

--- a/2.7/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/2.7/windows/windowsservercore-ltsc2016/Dockerfile
@@ -7,6 +7,7 @@ ENV PYTHON_RELEASE 2.7.14
 
 RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}.amd64.msi' -f $env:PYTHON_RELEASE, $env:PYTHON_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'python.msi'; \
 	\
 	Write-Host 'Installing ...'; \

--- a/3.6/windows/windowsservercore-1709/Dockerfile
+++ b/3.6/windows/windowsservercore-1709/Dockerfile
@@ -13,6 +13,7 @@ ENV PYTHON_RELEASE 3.6.5
 
 RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env:PYTHON_RELEASE, $env:PYTHON_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'python.exe'; \
 	\
 	Write-Host 'Installing ...'; \

--- a/3.6/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/3.6/windows/windowsservercore-ltsc2016/Dockerfile
@@ -13,6 +13,7 @@ ENV PYTHON_RELEASE 3.6.5
 
 RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env:PYTHON_RELEASE, $env:PYTHON_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'python.exe'; \
 	\
 	Write-Host 'Installing ...'; \

--- a/3.7-rc/windows/windowsservercore-1709/Dockerfile
+++ b/3.7-rc/windows/windowsservercore-1709/Dockerfile
@@ -13,6 +13,7 @@ ENV PYTHON_RELEASE 3.7.0
 
 RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env:PYTHON_RELEASE, $env:PYTHON_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'python.exe'; \
 	\
 	Write-Host 'Installing ...'; \

--- a/3.7-rc/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/3.7-rc/windows/windowsservercore-ltsc2016/Dockerfile
@@ -13,6 +13,7 @@ ENV PYTHON_RELEASE 3.7.0
 
 RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env:PYTHON_RELEASE, $env:PYTHON_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'python.exe'; \
 	\
 	Write-Host 'Installing ...'; \

--- a/Dockerfile-windowsservercore.template
+++ b/Dockerfile-windowsservercore.template
@@ -7,6 +7,7 @@ ENV PYTHON_RELEASE %%PLACEHOLDER%%
 
 RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env:PYTHON_RELEASE, $env:PYTHON_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'python.exe'; \
 	\
 	Write-Host 'Installing ...'; \


### PR DESCRIPTION
See also, https://github.com/docker-library/python/pull/228 and https://github.com/docker-library/openjdk/pull/182.