### PR TITLE
2.7/alpine3.7: Add nis libraries now that 2.7.15 is patched

### DIFF
--- a/2.7/alpine3.6/Dockerfile
+++ b/2.7/alpine3.6/Dockerfile
@@ -40,11 +40,11 @@ RUN set -ex \
 		gcc \
 		gdbm-dev \
 		libc-dev \
+		libressl \
+		libressl-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
-		libressl \
-		libressl-dev \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \

--- a/2.7/alpine3.7/Dockerfile
+++ b/2.7/alpine3.7/Dockerfile
@@ -40,11 +40,11 @@ RUN set -ex \
 		gcc \
 		gdbm-dev \
 		libc-dev \
+		libressl \
+		libressl-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
-		libressl \
-		libressl-dev \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \

--- a/2.7/alpine3.7/Dockerfile
+++ b/2.7/alpine3.7/Dockerfile
@@ -40,8 +40,10 @@ RUN set -ex \
 		gcc \
 		gdbm-dev \
 		libc-dev \
+		libnsl-dev \
 		libressl \
 		libressl-dev \
+		libtirpc-dev \
 		linux-headers \
 		make \
 		ncurses-dev \

--- a/3.4/alpine3.7/Dockerfile
+++ b/3.4/alpine3.7/Dockerfile
@@ -47,12 +47,12 @@ RUN set -ex \
 		libc-dev \
 		libffi-dev \
 		libnsl-dev \
+		libressl \
+		libressl-dev \
 		libtirpc-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
-		libressl \
-		libressl-dev \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \

--- a/3.5/alpine3.7/Dockerfile
+++ b/3.5/alpine3.7/Dockerfile
@@ -47,12 +47,12 @@ RUN set -ex \
 		libc-dev \
 		libffi-dev \
 		libnsl-dev \
+		libressl \
+		libressl-dev \
 		libtirpc-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
-		libressl \
-		libressl-dev \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \

--- a/3.6/alpine3.6/Dockerfile
+++ b/3.6/alpine3.6/Dockerfile
@@ -46,11 +46,11 @@ RUN set -ex \
 		gdbm-dev \
 		libc-dev \
 		libffi-dev \
+		libressl \
+		libressl-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
-		libressl \
-		libressl-dev \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \

--- a/3.6/alpine3.7/Dockerfile
+++ b/3.6/alpine3.7/Dockerfile
@@ -47,12 +47,12 @@ RUN set -ex \
 		libc-dev \
 		libffi-dev \
 		libnsl-dev \
+		libressl \
+		libressl-dev \
 		libtirpc-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
-		libressl \
-		libressl-dev \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \

--- a/3.7-rc/alpine3.7/Dockerfile
+++ b/3.7-rc/alpine3.7/Dockerfile
@@ -47,12 +47,12 @@ RUN set -ex \
 		libc-dev \
 		libffi-dev \
 		libnsl-dev \
+		openssl \
+		openssl-dev \
 		libtirpc-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
-		openssl \
-		openssl-dev \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -41,12 +41,12 @@ RUN set -ex \
 		libc-dev \
 		libffi-dev \
 		libnsl-dev \
+		libressl \
+		libressl-dev \
 		libtirpc-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
-		libressl \
-		libressl-dev \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \


### PR DESCRIPTION
The final fix for #247.