### PR TITLE
Add netbase so that `/etc/{protocols,rpc,services}` exists in slim images

### DIFF
--- a/2.7/jessie/slim/Dockerfile
+++ b/2.7/jessie/slim/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libreadline6 \
 		libsqlite3-0 \
 		libssl1.0.0 \
+		netbase \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF

--- a/2.7/stretch/slim/Dockerfile
+++ b/2.7/stretch/slim/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libreadline7 \
 		libsqlite3-0 \
 		libssl1.1 \
+		netbase \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF

--- a/3.4/jessie/slim/Dockerfile
+++ b/3.4/jessie/slim/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libreadline6 \
 		libsqlite3-0 \
 		libssl1.0.0 \
+		netbase \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D

--- a/3.5/jessie/slim/Dockerfile
+++ b/3.5/jessie/slim/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libreadline6 \
 		libsqlite3-0 \
 		libssl1.0.0 \
+		netbase \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D

--- a/3.6/jessie/slim/Dockerfile
+++ b/3.6/jessie/slim/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libreadline6 \
 		libsqlite3-0 \
 		libssl1.0.0 \
+		netbase \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D

--- a/3.6/stretch/slim/Dockerfile
+++ b/3.6/stretch/slim/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libreadline7 \
 		libsqlite3-0 \
 		libssl1.1 \
+		netbase \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D

--- a/3.7-rc/stretch/slim/Dockerfile
+++ b/3.7-rc/stretch/slim/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libreadline7 \
 		libsqlite3-0 \
 		libssl1.1 \
+		netbase \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libreadline7 \
 		libsqlite3-0 \
 		libssl1.1 \
+		netbase \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY %%PLACEHOLDER%%


### PR DESCRIPTION
```bash
# Before (on 2.7 jessie slim):
After this operation, 5518 kB of additional disk space will be used.

# After:
After this operation, 5586 kB of additional disk space will be used.
```

Fixes #270. It is a minimal size change, but if it is not merged, it can be a good reference to users missing `/etc/protocols`, `/etc/rpc` or `/etc/services`.

Related discussion: https://github.com/debuerreotype/docker-debian-artifacts/issues/36#issuecomment-385212707