### PR TITLE
Alpine: Don't install libraries for tkinter

### DIFF
--- a/2.7/alpine3.6/Dockerfile
+++ b/2.7/alpine3.6/Dockerfile
@@ -68,7 +68,10 @@ RUN set -ex \
 	&& make install \
 	\
 	&& runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+		scanelf --needed --nobanner --format '%f:%n#p' --recursive /usr/local \
+# don't install libraries for tkinter as it is rarely used inside a container
+			| grep -v tkinter \
+			| cut -d ':' -f 2 \
 			| tr ',' '\n' \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \

--- a/2.7/alpine3.7/Dockerfile
+++ b/2.7/alpine3.7/Dockerfile
@@ -70,7 +70,10 @@ RUN set -ex \
 	&& make install \
 	\
 	&& runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+		scanelf --needed --nobanner --format '%f:%n#p' --recursive /usr/local \
+# don't install libraries for tkinter as it is rarely used in a container
+			| grep -v tkinter \
+			| cut -d ':' -f 2 \
 			| tr ',' '\n' \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \

--- a/3.4/alpine3.7/Dockerfile
+++ b/3.4/alpine3.7/Dockerfile
@@ -78,7 +78,10 @@ RUN set -ex \
 	&& make install \
 	\
 	&& runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+		scanelf --needed --nobanner --format '%f:%n#p' --recursive /usr/local \
+# don't install libraries for tkinter as it is rarely used inside a container
+			| grep -v tkinter \
+			| cut -d ':' -f 2 \
 			| tr ',' '\n' \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \

--- a/3.5/alpine3.7/Dockerfile
+++ b/3.5/alpine3.7/Dockerfile
@@ -78,7 +78,10 @@ RUN set -ex \
 	&& make install \
 	\
 	&& runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+		scanelf --needed --nobanner --format '%f:%n#p' --recursive /usr/local \
+# don't install libraries for tkinter as it is rarely used inside a container
+			| grep -v tkinter \
+			| cut -d ':' -f 2 \
 			| tr ',' '\n' \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \

--- a/3.6/alpine3.6/Dockerfile
+++ b/3.6/alpine3.6/Dockerfile
@@ -78,7 +78,10 @@ RUN set -ex \
 	&& make install \
 	\
 	&& runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+		scanelf --needed --nobanner --format '%f:%n#p' --recursive /usr/local \
+# don't install libraries for tkinter as it is rarely used inside a container
+			| grep -v tkinter \
+			| cut -d ':' -f 2 \
 			| tr ',' '\n' \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \

--- a/3.6/alpine3.7/Dockerfile
+++ b/3.6/alpine3.7/Dockerfile
@@ -80,7 +80,10 @@ RUN set -ex \
 	&& make install \
 	\
 	&& runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+		scanelf --needed --nobanner --format '%f:%n#p' --recursive /usr/local \
+# don't install libraries for tkinter as it is rarely used inside a container
+			| grep -v tkinter \
+			| cut -d ':' -f 2 \
 			| tr ',' '\n' \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \

--- a/3.7/alpine3.7/Dockerfile
+++ b/3.7/alpine3.7/Dockerfile
@@ -80,7 +80,10 @@ RUN set -ex \
 	&& make install \
 	\
 	&& runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+		scanelf --needed --nobanner --format '%f:%n#p' --recursive /usr/local \
+# don't install libraries for tkinter as it is rarely used inside a container
+			| grep -v tkinter \
+			| cut -d ':' -f 2 \
 			| tr ',' '\n' \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -74,7 +74,10 @@ RUN set -ex \
 	&& make install \
 	\
 	&& runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+		scanelf --needed --nobanner --format '%f:%n#p' --recursive /usr/local \
+# don't install libraries for tkinter as it is rarely used inside a container
+			| grep -v tkinter \
+			| cut -d ':' -f 2 \
 			| tr ',' '\n' \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \


### PR DESCRIPTION
* tkinter is rarely used in a container
* The Debian slim images also don't include these libraries (and also still build the module)
* Requires >12MB of libraries (x11, freetype...)
* The module is still built, so if needed, the required libraries can be installed and the module should still work

```
python        2.7-alpine3.7-no-tkinter   de65e3e2a0c5        About a minute ago   57MB
python        3.6-alpine3.7-no-tkinter   682fd4b35b37        12 minutes ago       74.8MB
python        2.7-alpine3.7              93c09abcfe57        6 days ago           69.5MB
python        3.6-alpine3.7              27e79c0fa4d2        12 days ago          87.4MB
```