### PR TITLE
update.sh: Fix nis library condition

### DIFF
--- a/3.4/alpine3.7/Dockerfile
+++ b/3.4/alpine3.7/Dockerfile
@@ -46,10 +46,8 @@ RUN set -ex \
 		gdbm-dev \
 		libc-dev \
 		libffi-dev \
-		libnsl-dev \
 		libressl \
 		libressl-dev \
-		libtirpc-dev \
 		linux-headers \
 		make \
 		ncurses-dev \

--- a/3.5/alpine3.7/Dockerfile
+++ b/3.5/alpine3.7/Dockerfile
@@ -46,10 +46,8 @@ RUN set -ex \
 		gdbm-dev \
 		libc-dev \
 		libffi-dev \
-		libnsl-dev \
 		libressl \
 		libressl-dev \
-		libtirpc-dev \
 		linux-headers \
 		make \
 		ncurses-dev \

--- a/update.sh
+++ b/update.sh
@@ -159,9 +159,10 @@ for version in "${versions[@]}"; do
 			sed -ri -e 's/libressl/openssl/g' "$dir/Dockerfile"
 		fi
 
-		# Libraries to build the nis module available in Alpine 3.7, but also require this patch:
-		# https://bugs.python.org/issue32521
-		if [[ "$variant" == alpine* ]] && [[ "$variant" != alpine3.7 ]]; then
+		# Libraries to build the nis module only available in Alpine 3.7+.
+		# Also require this patch https://bugs.python.org/issue32521 only available in Python 2.7, 3.6+.
+		if [[ "$variant" == alpine* ]] && [[ "$version" == 3.4* || "$version" == 3.5* ]] \
+				|| [[ "$variant" == alpine3.6 ]]; then
 			sed -ri -e '/libnsl-dev/d' -e '/libtirpc-dev/d' "$dir/Dockerfile"
 		fi
 


### PR DESCRIPTION
Fixing my own patch... it broke slightly when the Python 3.4/3.5 were updated to use Alpine 3.7.

Also needed for Alpine 3.8.