### PR TITLE
alpine: Don't install ca-certificates on Alpine 3.7+

### DIFF
--- a/2.7/alpine3.6/Dockerfile
+++ b/2.7/alpine3.6/Dockerfile
@@ -15,8 +15,8 @@ ENV LANG C.UTF-8
 # https://github.com/docker-library/python/issues/147
 ENV PYTHONIOENCODING UTF-8
 
-# install libressl so that HTTPS works on Alpine <3.7
-RUN apk add --no-cache libressl
+# install ca-certificates so that HTTPS works consistently (other runtime dependencies for Python are installed later); only needed on Alpine 3.6 (3.7+ includes these in the base)
+RUN apk add --no-cache ca-certificates
 
 ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 ENV PYTHON_VERSION 2.7.15
@@ -24,6 +24,7 @@ ENV PYTHON_VERSION 2.7.15
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
+		libressl \
 		tar \
 		xz \
 	\
@@ -46,6 +47,7 @@ RUN set -ex \
 		gcc \
 		gdbm-dev \
 		libc-dev \
+		libressl \
 		libressl-dev \
 		linux-headers \
 		make \
@@ -93,6 +95,8 @@ RUN set -ex \
 ENV PYTHON_PIP_VERSION 18.0
 
 RUN set -ex; \
+	\
+	apk add --no-cache --virtual .fetch-deps libressl; trap 'apk del .fetch-deps' EXIT; \
 	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
 	\

--- a/2.7/alpine3.6/Dockerfile
+++ b/2.7/alpine3.6/Dockerfile
@@ -15,9 +15,8 @@ ENV LANG C.UTF-8
 # https://github.com/docker-library/python/issues/147
 ENV PYTHONIOENCODING UTF-8
 
-# install ca-certificates so that HTTPS works consistently
-# the other runtime dependencies for Python are installed later
-RUN apk add --no-cache ca-certificates
+# install libressl so that HTTPS works on Alpine <3.7
+RUN apk add --no-cache libressl
 
 ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 ENV PYTHON_VERSION 2.7.15
@@ -25,7 +24,6 @@ ENV PYTHON_VERSION 2.7.15
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
-		libressl \
 		tar \
 		xz \
 	\
@@ -48,7 +46,6 @@ RUN set -ex \
 		gcc \
 		gdbm-dev \
 		libc-dev \
-		libressl \
 		libressl-dev \
 		linux-headers \
 		make \
@@ -97,11 +94,7 @@ ENV PYTHON_PIP_VERSION 18.0
 
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .fetch-deps libressl; \
-	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	apk del .fetch-deps; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/2.7/alpine3.7/Dockerfile
+++ b/2.7/alpine3.7/Dockerfile
@@ -15,9 +15,8 @@ ENV LANG C.UTF-8
 # https://github.com/docker-library/python/issues/147
 ENV PYTHONIOENCODING UTF-8
 
-# install ca-certificates so that HTTPS works consistently
-# the other runtime dependencies for Python are installed later
-RUN apk add --no-cache ca-certificates
+# install libressl so that HTTPS works on Alpine <3.7
+# RUN apk add --no-cache libressl
 
 ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 ENV PYTHON_VERSION 2.7.15
@@ -25,7 +24,6 @@ ENV PYTHON_VERSION 2.7.15
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
-		libressl \
 		tar \
 		xz \
 	\
@@ -49,7 +47,6 @@ RUN set -ex \
 		gdbm-dev \
 		libc-dev \
 		libnsl-dev \
-		libressl \
 		libressl-dev \
 		libtirpc-dev \
 		linux-headers \
@@ -99,11 +96,7 @@ ENV PYTHON_PIP_VERSION 18.0
 
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .fetch-deps libressl; \
-	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	apk del .fetch-deps; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/2.7/alpine3.7/Dockerfile
+++ b/2.7/alpine3.7/Dockerfile
@@ -15,9 +15,6 @@ ENV LANG C.UTF-8
 # https://github.com/docker-library/python/issues/147
 ENV PYTHONIOENCODING UTF-8
 
-# install libressl so that HTTPS works on Alpine <3.7
-# RUN apk add --no-cache libressl
-
 ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 ENV PYTHON_VERSION 2.7.15
 

--- a/2.7/alpine3.8/Dockerfile
+++ b/2.7/alpine3.8/Dockerfile
@@ -15,9 +15,8 @@ ENV LANG C.UTF-8
 # https://github.com/docker-library/python/issues/147
 ENV PYTHONIOENCODING UTF-8
 
-# install ca-certificates so that HTTPS works consistently
-# the other runtime dependencies for Python are installed later
-RUN apk add --no-cache ca-certificates
+# install libressl so that HTTPS works on Alpine <3.7
+# RUN apk add --no-cache libressl
 
 ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 ENV PYTHON_VERSION 2.7.15
@@ -25,7 +24,6 @@ ENV PYTHON_VERSION 2.7.15
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
-		libressl \
 		tar \
 		xz \
 	\
@@ -49,7 +47,6 @@ RUN set -ex \
 		gdbm-dev \
 		libc-dev \
 		libnsl-dev \
-		libressl \
 		libressl-dev \
 		libtirpc-dev \
 		linux-headers \
@@ -99,11 +96,7 @@ ENV PYTHON_PIP_VERSION 18.0
 
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .fetch-deps libressl; \
-	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	apk del .fetch-deps; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/2.7/alpine3.8/Dockerfile
+++ b/2.7/alpine3.8/Dockerfile
@@ -15,9 +15,6 @@ ENV LANG C.UTF-8
 # https://github.com/docker-library/python/issues/147
 ENV PYTHONIOENCODING UTF-8
 
-# install libressl so that HTTPS works on Alpine <3.7
-# RUN apk add --no-cache libressl
-
 ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 ENV PYTHON_VERSION 2.7.15
 

--- a/3.4/alpine3.7/Dockerfile
+++ b/3.4/alpine3.7/Dockerfile
@@ -13,9 +13,8 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install ca-certificates so that HTTPS works consistently
-# the other runtime dependencies for Python are installed later
-RUN apk add --no-cache ca-certificates
+# install libressl so that HTTPS works on Alpine <3.7
+# RUN apk add --no-cache libressl
 
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.4.8
@@ -23,7 +22,6 @@ ENV PYTHON_VERSION 3.4.8
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
-		libressl \
 		tar \
 		xz \
 	\
@@ -48,7 +46,6 @@ RUN set -ex \
 		gdbm-dev \
 		libc-dev \
 		libffi-dev \
-		libressl \
 		libressl-dev \
 		linux-headers \
 		make \
@@ -108,11 +105,7 @@ ENV PYTHON_PIP_VERSION 18.0
 
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .fetch-deps libressl; \
-	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	apk del .fetch-deps; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/3.4/alpine3.7/Dockerfile
+++ b/3.4/alpine3.7/Dockerfile
@@ -13,9 +13,6 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install libressl so that HTTPS works on Alpine <3.7
-# RUN apk add --no-cache libressl
-
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.4.8
 

--- a/3.4/alpine3.8/Dockerfile
+++ b/3.4/alpine3.8/Dockerfile
@@ -13,9 +13,8 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install ca-certificates so that HTTPS works consistently
-# the other runtime dependencies for Python are installed later
-RUN apk add --no-cache ca-certificates
+# install libressl so that HTTPS works on Alpine <3.7
+# RUN apk add --no-cache libressl
 
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.4.8
@@ -23,7 +22,6 @@ ENV PYTHON_VERSION 3.4.8
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
-		libressl \
 		tar \
 		xz \
 	\
@@ -48,7 +46,6 @@ RUN set -ex \
 		gdbm-dev \
 		libc-dev \
 		libffi-dev \
-		libressl \
 		libressl-dev \
 		linux-headers \
 		make \
@@ -108,11 +105,7 @@ ENV PYTHON_PIP_VERSION 18.0
 
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .fetch-deps libressl; \
-	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	apk del .fetch-deps; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/3.4/alpine3.8/Dockerfile
+++ b/3.4/alpine3.8/Dockerfile
@@ -13,9 +13,6 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install libressl so that HTTPS works on Alpine <3.7
-# RUN apk add --no-cache libressl
-
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.4.8
 

--- a/3.5/alpine3.7/Dockerfile
+++ b/3.5/alpine3.7/Dockerfile
@@ -13,9 +13,6 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install libressl so that HTTPS works on Alpine <3.7
-# RUN apk add --no-cache libressl
-
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.5.5
 

--- a/3.5/alpine3.7/Dockerfile
+++ b/3.5/alpine3.7/Dockerfile
@@ -13,9 +13,8 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install ca-certificates so that HTTPS works consistently
-# the other runtime dependencies for Python are installed later
-RUN apk add --no-cache ca-certificates
+# install libressl so that HTTPS works on Alpine <3.7
+# RUN apk add --no-cache libressl
 
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.5.5
@@ -23,7 +22,6 @@ ENV PYTHON_VERSION 3.5.5
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
-		libressl \
 		tar \
 		xz \
 	\
@@ -48,7 +46,6 @@ RUN set -ex \
 		gdbm-dev \
 		libc-dev \
 		libffi-dev \
-		libressl \
 		libressl-dev \
 		linux-headers \
 		make \
@@ -108,11 +105,7 @@ ENV PYTHON_PIP_VERSION 18.0
 
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .fetch-deps libressl; \
-	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	apk del .fetch-deps; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/3.5/alpine3.8/Dockerfile
+++ b/3.5/alpine3.8/Dockerfile
@@ -13,9 +13,6 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install libressl so that HTTPS works on Alpine <3.7
-# RUN apk add --no-cache libressl
-
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.5.5
 

--- a/3.5/alpine3.8/Dockerfile
+++ b/3.5/alpine3.8/Dockerfile
@@ -13,9 +13,8 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install ca-certificates so that HTTPS works consistently
-# the other runtime dependencies for Python are installed later
-RUN apk add --no-cache ca-certificates
+# install libressl so that HTTPS works on Alpine <3.7
+# RUN apk add --no-cache libressl
 
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.5.5
@@ -23,7 +22,6 @@ ENV PYTHON_VERSION 3.5.5
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
-		openssl \
 		tar \
 		xz \
 	\
@@ -48,7 +46,6 @@ RUN set -ex \
 		gdbm-dev \
 		libc-dev \
 		libffi-dev \
-		openssl \
 		openssl-dev \
 		linux-headers \
 		make \
@@ -108,11 +105,7 @@ ENV PYTHON_PIP_VERSION 18.0
 
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .fetch-deps openssl; \
-	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	apk del .fetch-deps; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/3.6/alpine3.6/Dockerfile
+++ b/3.6/alpine3.6/Dockerfile
@@ -13,8 +13,8 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install libressl so that HTTPS works on Alpine <3.7
-RUN apk add --no-cache libressl
+# install ca-certificates so that HTTPS works consistently (other runtime dependencies for Python are installed later); only needed on Alpine 3.6 (3.7+ includes these in the base)
+RUN apk add --no-cache ca-certificates
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.6.6
@@ -22,6 +22,7 @@ ENV PYTHON_VERSION 3.6.6
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
+		libressl \
 		tar \
 		xz \
 	\
@@ -46,6 +47,7 @@ RUN set -ex \
 		gdbm-dev \
 		libc-dev \
 		libffi-dev \
+		libressl \
 		libressl-dev \
 		linux-headers \
 		make \
@@ -104,6 +106,8 @@ RUN cd /usr/local/bin \
 ENV PYTHON_PIP_VERSION 18.0
 
 RUN set -ex; \
+	\
+	apk add --no-cache --virtual .fetch-deps libressl; trap 'apk del .fetch-deps' EXIT; \
 	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
 	\

--- a/3.6/alpine3.6/Dockerfile
+++ b/3.6/alpine3.6/Dockerfile
@@ -13,9 +13,8 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install ca-certificates so that HTTPS works consistently
-# the other runtime dependencies for Python are installed later
-RUN apk add --no-cache ca-certificates
+# install libressl so that HTTPS works on Alpine <3.7
+RUN apk add --no-cache libressl
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.6.6
@@ -23,7 +22,6 @@ ENV PYTHON_VERSION 3.6.6
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
-		libressl \
 		tar \
 		xz \
 	\
@@ -48,7 +46,6 @@ RUN set -ex \
 		gdbm-dev \
 		libc-dev \
 		libffi-dev \
-		libressl \
 		libressl-dev \
 		linux-headers \
 		make \
@@ -108,11 +105,7 @@ ENV PYTHON_PIP_VERSION 18.0
 
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .fetch-deps libressl; \
-	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	apk del .fetch-deps; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/3.6/alpine3.7/Dockerfile
+++ b/3.6/alpine3.7/Dockerfile
@@ -13,9 +13,6 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install libressl so that HTTPS works on Alpine <3.7
-# RUN apk add --no-cache libressl
-
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.6.6
 

--- a/3.6/alpine3.7/Dockerfile
+++ b/3.6/alpine3.7/Dockerfile
@@ -13,9 +13,8 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install ca-certificates so that HTTPS works consistently
-# the other runtime dependencies for Python are installed later
-RUN apk add --no-cache ca-certificates
+# install libressl so that HTTPS works on Alpine <3.7
+# RUN apk add --no-cache libressl
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.6.6
@@ -23,7 +22,6 @@ ENV PYTHON_VERSION 3.6.6
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
-		libressl \
 		tar \
 		xz \
 	\
@@ -49,7 +47,6 @@ RUN set -ex \
 		libc-dev \
 		libffi-dev \
 		libnsl-dev \
-		libressl \
 		libressl-dev \
 		libtirpc-dev \
 		linux-headers \
@@ -110,11 +107,7 @@ ENV PYTHON_PIP_VERSION 18.0
 
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .fetch-deps libressl; \
-	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	apk del .fetch-deps; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/3.6/alpine3.8/Dockerfile
+++ b/3.6/alpine3.8/Dockerfile
@@ -13,9 +13,6 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install libressl so that HTTPS works on Alpine <3.7
-# RUN apk add --no-cache libressl
-
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.6.6
 

--- a/3.6/alpine3.8/Dockerfile
+++ b/3.6/alpine3.8/Dockerfile
@@ -13,9 +13,8 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install ca-certificates so that HTTPS works consistently
-# the other runtime dependencies for Python are installed later
-RUN apk add --no-cache ca-certificates
+# install libressl so that HTTPS works on Alpine <3.7
+# RUN apk add --no-cache libressl
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.6.6
@@ -23,7 +22,6 @@ ENV PYTHON_VERSION 3.6.6
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
-		libressl \
 		tar \
 		xz \
 	\
@@ -49,7 +47,6 @@ RUN set -ex \
 		libc-dev \
 		libffi-dev \
 		libnsl-dev \
-		libressl \
 		libressl-dev \
 		libtirpc-dev \
 		linux-headers \
@@ -110,11 +107,7 @@ ENV PYTHON_PIP_VERSION 18.0
 
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .fetch-deps libressl; \
-	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	apk del .fetch-deps; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/3.7/alpine3.7/Dockerfile
+++ b/3.7/alpine3.7/Dockerfile
@@ -13,9 +13,6 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install libressl so that HTTPS works on Alpine <3.7
-# RUN apk add --no-cache libressl
-
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.7.0
 

--- a/3.7/alpine3.7/Dockerfile
+++ b/3.7/alpine3.7/Dockerfile
@@ -13,9 +13,8 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install ca-certificates so that HTTPS works consistently
-# the other runtime dependencies for Python are installed later
-RUN apk add --no-cache ca-certificates
+# install libressl so that HTTPS works on Alpine <3.7
+# RUN apk add --no-cache libressl
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.7.0
@@ -23,7 +22,6 @@ ENV PYTHON_VERSION 3.7.0
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
-		openssl \
 		tar \
 		xz \
 	\
@@ -49,7 +47,6 @@ RUN set -ex \
 		libc-dev \
 		libffi-dev \
 		libnsl-dev \
-		openssl \
 		openssl-dev \
 		libtirpc-dev \
 		linux-headers \
@@ -110,11 +107,7 @@ ENV PYTHON_PIP_VERSION 18.0
 
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .fetch-deps openssl; \
-	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	apk del .fetch-deps; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/3.7/alpine3.8/Dockerfile
+++ b/3.7/alpine3.8/Dockerfile
@@ -13,9 +13,6 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install libressl so that HTTPS works on Alpine <3.7
-# RUN apk add --no-cache libressl
-
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.7.0
 

--- a/3.7/alpine3.8/Dockerfile
+++ b/3.7/alpine3.8/Dockerfile
@@ -13,9 +13,8 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install ca-certificates so that HTTPS works consistently
-# the other runtime dependencies for Python are installed later
-RUN apk add --no-cache ca-certificates
+# install libressl so that HTTPS works on Alpine <3.7
+# RUN apk add --no-cache libressl
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.7.0
@@ -23,7 +22,6 @@ ENV PYTHON_VERSION 3.7.0
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
-		libressl \
 		tar \
 		xz \
 	\
@@ -49,7 +47,6 @@ RUN set -ex \
 		libc-dev \
 		libffi-dev \
 		libnsl-dev \
-		libressl \
 		libressl-dev \
 		libtirpc-dev \
 		linux-headers \
@@ -110,11 +107,7 @@ ENV PYTHON_PIP_VERSION 18.0
 
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .fetch-deps libressl; \
-	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	apk del .fetch-deps; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -7,8 +7,8 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install libressl so that HTTPS works on Alpine <3.7
-# RUN apk add --no-cache libressl
+# install ca-certificates so that HTTPS works consistently (other runtime dependencies for Python are installed later); only needed on Alpine 3.6 (3.7+ includes these in the base)
+RUN apk add --no-cache ca-certificates
 
 ENV GPG_KEY %%PLACEHOLDER%%
 ENV PYTHON_VERSION %%PLACEHOLDER%%
@@ -16,6 +16,7 @@ ENV PYTHON_VERSION %%PLACEHOLDER%%
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
+		libressl \
 		tar \
 		xz \
 	\
@@ -41,6 +42,7 @@ RUN set -ex \
 		libc-dev \
 		libffi-dev \
 		libnsl-dev \
+		libressl \
 		libressl-dev \
 		libtirpc-dev \
 		linux-headers \
@@ -100,6 +102,8 @@ RUN cd /usr/local/bin \
 ENV PYTHON_PIP_VERSION %%PLACEHOLDER%%
 
 RUN set -ex; \
+	\
+	apk add --no-cache --virtual .fetch-deps libressl; trap 'apk del .fetch-deps' EXIT; \
 	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
 	\

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -7,9 +7,8 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install ca-certificates so that HTTPS works consistently
-# the other runtime dependencies for Python are installed later
-RUN apk add --no-cache ca-certificates
+# install libressl so that HTTPS works on Alpine <3.7
+# RUN apk add --no-cache libressl
 
 ENV GPG_KEY %%PLACEHOLDER%%
 ENV PYTHON_VERSION %%PLACEHOLDER%%
@@ -17,7 +16,6 @@ ENV PYTHON_VERSION %%PLACEHOLDER%%
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
-		libressl \
 		tar \
 		xz \
 	\
@@ -43,7 +41,6 @@ RUN set -ex \
 		libc-dev \
 		libffi-dev \
 		libnsl-dev \
-		libressl \
 		libressl-dev \
 		libtirpc-dev \
 		linux-headers \
@@ -104,11 +101,7 @@ ENV PYTHON_PIP_VERSION %%PLACEHOLDER%%
 
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .fetch-deps libressl; \
-	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	apk del .fetch-deps; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/Dockerfile-caveman-alpine.template
+++ b/Dockerfile-caveman-alpine.template
@@ -9,9 +9,8 @@ ENV LANG C.UTF-8
 # https://github.com/docker-library/python/issues/147
 ENV PYTHONIOENCODING UTF-8
 
-# install ca-certificates so that HTTPS works consistently
-# the other runtime dependencies for Python are installed later
-RUN apk add --no-cache ca-certificates
+# install libressl so that HTTPS works on Alpine <3.7
+# RUN apk add --no-cache libressl
 
 ENV GPG_KEY %%PLACEHOLDER%%
 ENV PYTHON_VERSION %%PLACEHOLDER%%
@@ -19,7 +18,6 @@ ENV PYTHON_VERSION %%PLACEHOLDER%%
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
-		libressl \
 		tar \
 		xz \
 	\
@@ -43,7 +41,6 @@ RUN set -ex \
 		gdbm-dev \
 		libc-dev \
 		libnsl-dev \
-		libressl \
 		libressl-dev \
 		libtirpc-dev \
 		linux-headers \
@@ -93,11 +90,7 @@ ENV PYTHON_PIP_VERSION %%PLACEHOLDER%%
 
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .fetch-deps libressl; \
-	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	apk del .fetch-deps; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/Dockerfile-caveman-alpine.template
+++ b/Dockerfile-caveman-alpine.template
@@ -9,8 +9,8 @@ ENV LANG C.UTF-8
 # https://github.com/docker-library/python/issues/147
 ENV PYTHONIOENCODING UTF-8
 
-# install libressl so that HTTPS works on Alpine <3.7
-# RUN apk add --no-cache libressl
+# install ca-certificates so that HTTPS works consistently (other runtime dependencies for Python are installed later); only needed on Alpine 3.6 (3.7+ includes these in the base)
+RUN apk add --no-cache ca-certificates
 
 ENV GPG_KEY %%PLACEHOLDER%%
 ENV PYTHON_VERSION %%PLACEHOLDER%%
@@ -18,6 +18,7 @@ ENV PYTHON_VERSION %%PLACEHOLDER%%
 RUN set -ex \
 	&& apk add --no-cache --virtual .fetch-deps \
 		gnupg \
+		libressl \
 		tar \
 		xz \
 	\
@@ -41,6 +42,7 @@ RUN set -ex \
 		gdbm-dev \
 		libc-dev \
 		libnsl-dev \
+		libressl \
 		libressl-dev \
 		libtirpc-dev \
 		linux-headers \
@@ -89,6 +91,8 @@ RUN set -ex \
 ENV PYTHON_PIP_VERSION %%PLACEHOLDER%%
 
 RUN set -ex; \
+	\
+	apk add --no-cache --virtual .fetch-deps libressl; trap 'apk del .fetch-deps' EXIT; \
 	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
 	\

--- a/update.sh
+++ b/update.sh
@@ -152,12 +152,17 @@ for version in "${versions[@]}"; do
 			wheezy) sed -ri -e 's/dpkg-architecture --query /dpkg-architecture -q/g' "$dir/Dockerfile" ;;
 		esac
 
+		if [[ "$v" == alpine* ]] && [ "$v" != 'alpine3.6' ]; then
+			# https://github.com/docker-library/python/pull/307
+			# on Alpine 3.6 it's necessary to install libressl to get working HTTPS with wget (and ca-certificates for Python's runtime), but later versions don't require this (support for both is baked into the base)
+			sed -ri -e '/(libressl|openssl|ca-certificates)([ ;]|$)/d' "$dir/Dockerfile"
+
+			# remove any double-empty (or double-empty-continuation) lines the above created
+			uniq "$dir/Dockerfile" > "$dir/Dockerfile.new"
+			mv "$dir/Dockerfile.new" "$dir/Dockerfile"
+		fi
+
 		case "$version/$v" in
-			# On Alpine 3.6 it's necessary to install libressl to get working HTTPS.
-			# Later Alpine versions have CA certificates pre-installed.
-			*/alpine3.6)
-				sed -ri -e '/^# .* libressl$/s/^# //' "$dir/Dockerfile"
-				;;& # (other patches needed for Alpine 3.6 in later blocks)
 			# https://bugs.python.org/issue32598 (Python 3.7.0b1+)
 			# TL;DR: Python 3.7+ uses OpenSSL functionality which LibreSSL 2.6.x in Alpine 3.7 doesn't implement
 			# Python 3.5 on Alpine 3.8 needs OpenSSL too

--- a/update.sh
+++ b/update.sh
@@ -153,11 +153,16 @@ for version in "${versions[@]}"; do
 		esac
 
 		case "$version/$v" in
+			# On Alpine 3.6 it's necessary to install libressl to get working HTTPS.
+			# Later Alpine versions have CA certificates pre-installed.
+			*/alpine3.6)
+				sed -ri -e '/^# .* libressl$/s/^# //' "$dir/Dockerfile"
+				;;& # (other patches needed for Alpine 3.6 in later blocks)
 			# https://bugs.python.org/issue32598 (Python 3.7.0b1+)
 			# TL;DR: Python 3.7+ uses OpenSSL functionality which LibreSSL 2.6.x in Alpine 3.7 doesn't implement
 			# Python 3.5 on Alpine 3.8 needs OpenSSL too
 			3.7*/alpine3.7 | 3.5*/alpine3.8)
-				sed -ri -e 's/libressl/openssl/g' "$dir/Dockerfile"
+				sed -ri -e 's/libressl-dev/openssl-dev/g' "$dir/Dockerfile"
 				;;& # (3.5*/alpine* needs to match the next block too)
 			# Libraries to build the nis module only available in Alpine 3.7+.
 			# Also require this patch https://bugs.python.org/issue32521 only available in Python 2.7, 3.6+.


### PR DESCRIPTION
* CA certs come bundled on Alpine 3.7+
* On Alpine 3.6, rather install `libressl` which also include CA certs, allows us to use wget, and doesn't increase the size over `ca-certificates`

No significant change to image size (decreases ~0.7MB). Mostly a cleanup.