### PR TITLE
Update defaultAlpineVersion, from v3.7 to v3.8

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -8,7 +8,7 @@ declare -A aliases=(
 )
 
 defaultDebianSuite='stretch'
-defaultAlpineVersion='3.7'
+defaultAlpineVersion='3.8'
 
 self="$(basename "$BASH_SOURCE")"
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"


### PR DESCRIPTION
Alpine Linux v3.8 was released for weeks, reference to the time for changing `defaultAlpineVersion` from `3.6` to `3.7`, I guess it's time to bump the default Alpine based image to v3.8?

Thanks a lot!