### PR TITLE
Reduce clone depth of official-images on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ matrix:
       env: VERSION=2.7 VARIANT=alpine3.9
 
 install:
-  - git clone https://github.com/docker-library/official-images.git ~/official-images
+  - git clone --depth 1 https://github.com/docker-library/official-images.git ~/official-images
   - if [ "$TRAVIS_OS_NAME" = 'linux' ]; then wget -qO- 'https://github.com/tianon/pgp-happy-eyeballs/raw/master/hack-my-builds.sh' | bash; fi
 
 before_script:


### PR DESCRIPTION
Only the latest version of official-images repo is needed. We can speed up this part in the CI build.
(As you can see that the repository already has almost 9k commits)