### PR TITLE
Install ca-certificates on Alpine 3.7+ again

### DIFF
--- a/2.7/alpine3.6/Dockerfile
+++ b/2.7/alpine3.6/Dockerfile
@@ -15,7 +15,8 @@ ENV LANG C.UTF-8
 # https://github.com/docker-library/python/issues/147
 ENV PYTHONIOENCODING UTF-8
 
-# install ca-certificates so that HTTPS works consistently (other runtime dependencies for Python are installed later); only needed on Alpine 3.6 (3.7+ includes these in the base)
+# install ca-certificates so that HTTPS works consistently
+# other runtime dependencies for Python are installed later
 RUN apk add --no-cache ca-certificates
 
 ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF

--- a/2.7/alpine3.7/Dockerfile
+++ b/2.7/alpine3.7/Dockerfile
@@ -15,6 +15,10 @@ ENV LANG C.UTF-8
 # https://github.com/docker-library/python/issues/147
 ENV PYTHONIOENCODING UTF-8
 
+# install ca-certificates so that HTTPS works consistently
+# other runtime dependencies for Python are installed later
+RUN apk add --no-cache ca-certificates
+
 ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 ENV PYTHON_VERSION 2.7.15
 

--- a/2.7/alpine3.8/Dockerfile
+++ b/2.7/alpine3.8/Dockerfile
@@ -15,6 +15,10 @@ ENV LANG C.UTF-8
 # https://github.com/docker-library/python/issues/147
 ENV PYTHONIOENCODING UTF-8
 
+# install ca-certificates so that HTTPS works consistently
+# other runtime dependencies for Python are installed later
+RUN apk add --no-cache ca-certificates
+
 ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 ENV PYTHON_VERSION 2.7.15
 

--- a/3.4/alpine3.7/Dockerfile
+++ b/3.4/alpine3.7/Dockerfile
@@ -13,6 +13,10 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
+# install ca-certificates so that HTTPS works consistently
+# other runtime dependencies for Python are installed later
+RUN apk add --no-cache ca-certificates
+
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.4.8
 

--- a/3.4/alpine3.8/Dockerfile
+++ b/3.4/alpine3.8/Dockerfile
@@ -13,6 +13,10 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
+# install ca-certificates so that HTTPS works consistently
+# other runtime dependencies for Python are installed later
+RUN apk add --no-cache ca-certificates
+
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.4.8
 

--- a/3.5/alpine3.7/Dockerfile
+++ b/3.5/alpine3.7/Dockerfile
@@ -13,6 +13,10 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
+# install ca-certificates so that HTTPS works consistently
+# other runtime dependencies for Python are installed later
+RUN apk add --no-cache ca-certificates
+
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.5.5
 

--- a/3.5/alpine3.8/Dockerfile
+++ b/3.5/alpine3.8/Dockerfile
@@ -13,6 +13,10 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
+# install ca-certificates so that HTTPS works consistently
+# other runtime dependencies for Python are installed later
+RUN apk add --no-cache ca-certificates
+
 ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.5.5
 

--- a/3.6/alpine3.6/Dockerfile
+++ b/3.6/alpine3.6/Dockerfile
@@ -13,7 +13,8 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install ca-certificates so that HTTPS works consistently (other runtime dependencies for Python are installed later); only needed on Alpine 3.6 (3.7+ includes these in the base)
+# install ca-certificates so that HTTPS works consistently
+# other runtime dependencies for Python are installed later
 RUN apk add --no-cache ca-certificates
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D

--- a/3.6/alpine3.7/Dockerfile
+++ b/3.6/alpine3.7/Dockerfile
@@ -13,6 +13,10 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
+# install ca-certificates so that HTTPS works consistently
+# other runtime dependencies for Python are installed later
+RUN apk add --no-cache ca-certificates
+
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.6.6
 

--- a/3.6/alpine3.8/Dockerfile
+++ b/3.6/alpine3.8/Dockerfile
@@ -13,6 +13,10 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
+# install ca-certificates so that HTTPS works consistently
+# other runtime dependencies for Python are installed later
+RUN apk add --no-cache ca-certificates
+
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.6.6
 

--- a/3.7/alpine3.7/Dockerfile
+++ b/3.7/alpine3.7/Dockerfile
@@ -13,6 +13,10 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
+# install ca-certificates so that HTTPS works consistently
+# other runtime dependencies for Python are installed later
+RUN apk add --no-cache ca-certificates
+
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.7.0
 

--- a/3.7/alpine3.8/Dockerfile
+++ b/3.7/alpine3.8/Dockerfile
@@ -13,6 +13,10 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
+# install ca-certificates so that HTTPS works consistently
+# other runtime dependencies for Python are installed later
+RUN apk add --no-cache ca-certificates
+
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.7.0
 

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -7,7 +7,8 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# install ca-certificates so that HTTPS works consistently (other runtime dependencies for Python are installed later); only needed on Alpine 3.6 (3.7+ includes these in the base)
+# install ca-certificates so that HTTPS works consistently
+# other runtime dependencies for Python are installed later
 RUN apk add --no-cache ca-certificates
 
 ENV GPG_KEY %%PLACEHOLDER%%

--- a/Dockerfile-caveman-alpine.template
+++ b/Dockerfile-caveman-alpine.template
@@ -9,7 +9,8 @@ ENV LANG C.UTF-8
 # https://github.com/docker-library/python/issues/147
 ENV PYTHONIOENCODING UTF-8
 
-# install ca-certificates so that HTTPS works consistently (other runtime dependencies for Python are installed later); only needed on Alpine 3.6 (3.7+ includes these in the base)
+# install ca-certificates so that HTTPS works consistently
+# other runtime dependencies for Python are installed later
 RUN apk add --no-cache ca-certificates
 
 ENV GPG_KEY %%PLACEHOLDER%%

--- a/update.sh
+++ b/update.sh
@@ -155,7 +155,10 @@ for version in "${versions[@]}"; do
 		if [[ "$v" == alpine* ]] && [ "$v" != 'alpine3.6' ]; then
 			# https://github.com/docker-library/python/pull/307
 			# on Alpine 3.6 it's necessary to install libressl to get working HTTPS with wget (and ca-certificates for Python's runtime), but later versions don't require this (support for both is baked into the base)
-			sed -ri -e '/(libressl|openssl|ca-certificates)([ ;]|$)/d' "$dir/Dockerfile"
+			# https://github.com/docker-library/python/issues/324
+			# while Alpine 3.7+ includes CA certs in the base (/etc/ssl/cert.pem) and this is sufficient for working HTTPS in wget and Python, some software (notably, any Golang code) expects CA certs at /etc/ssl/certs/
+			# this means it is still necessary to install ca-certificates in all Alpine images for consistently working HTTPS
+			sed -ri -e '/(libressl|openssl)([ ;]|$)/d' "$dir/Dockerfile"
 
 			# remove any double-empty (or double-empty-continuation) lines the above created
 			uniq "$dir/Dockerfile" > "$dir/Dockerfile.new"


### PR DESCRIPTION
Fixes #324, partially reverts e078edc.

I swear CA certificates on Alpine Linux (or I guess any Linux) will break me :(. It's 2018, HTTPS should _just work_.