### PR TITLE
Python 3.7: Install libuuid packages for native _uuid module

### DIFF
--- a/3.7/alpine3.7/Dockerfile
+++ b/3.7/alpine3.7/Dockerfile
@@ -59,6 +59,7 @@ RUN set -ex \
 		tcl-dev \
 		tk \
 		tk-dev \
+		util-linux-dev \
 		xz-dev \
 		zlib-dev \
 # add build deps before removing fetch deps in case there's overlap

--- a/3.7/alpine3.8/Dockerfile
+++ b/3.7/alpine3.8/Dockerfile
@@ -59,6 +59,7 @@ RUN set -ex \
 		tcl-dev \
 		tk \
 		tk-dev \
+		util-linux-dev \
 		xz-dev \
 		zlib-dev \
 # add build deps before removing fetch deps in case there's overlap

--- a/3.7/stretch/Dockerfile
+++ b/3.7/stretch/Dockerfile
@@ -16,6 +16,7 @@ ENV LANG C.UTF-8
 # extra dependencies (over what buildpack-deps already includes)
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		tk-dev \
+		uuid-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D

--- a/3.7/stretch/slim/Dockerfile
+++ b/3.7/stretch/slim/Dockerfile
@@ -40,6 +40,7 @@ RUN set -ex \
 		libssl-dev \
 		make \
 		tk-dev \
+		uuid-dev \
 		wget \
 		xz-utils \
 		zlib1g-dev \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -55,6 +55,7 @@ RUN set -ex \
 		tcl-dev \
 		tk \
 		tk-dev \
+		util-linux-dev \
 		xz-dev \
 		zlib-dev \
 # add build deps before removing fetch deps in case there's overlap

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Python 3.4 on Stretch+ needs to use an older version of "libssl-dev" (these lines both get removed for every other combination)
 		libssl-dev \
 		tk-dev \
+		uuid-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY %%PLACEHOLDER%%

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -34,6 +34,7 @@ RUN set -ex \
 		libssl-dev \
 		make \
 		tk-dev \
+		uuid-dev \
 		wget \
 		xz-utils \
 		zlib1g-dev \

--- a/update.sh
+++ b/update.sh
@@ -165,6 +165,19 @@ for version in "${versions[@]}"; do
 			mv "$dir/Dockerfile.new" "$dir/Dockerfile"
 		fi
 
+		# https://bugs.python.org/issue11063, https://bugs.python.org/issue20519 (Python 3.7.0+)
+		# A new native _uuid module improves uuid import time and avoids using ctypes.
+		# This requires the development libuuid headers.
+		case "$version" in
+			3.4* | 3.5* | 3.6*)
+				if [[ "$v" = alpine* ]]; then
+					sed -ri -e '/util-linux-dev/d' "$dir/Dockerfile"
+				else
+					sed -ri -e '/uuid-dev/d' "$dir/Dockerfile"
+				fi
+				;;
+		esac
+
 		case "$version/$v" in
 			# https://bugs.python.org/issue32598 (Python 3.7.0b1+)
 			# TL;DR: Python 3.7+ uses OpenSSL functionality which LibreSSL 2.6.x in Alpine 3.7 doesn't implement

--- a/update.sh
+++ b/update.sh
@@ -165,19 +165,6 @@ for version in "${versions[@]}"; do
 			mv "$dir/Dockerfile.new" "$dir/Dockerfile"
 		fi
 
-		# https://bugs.python.org/issue11063, https://bugs.python.org/issue20519 (Python 3.7.0+)
-		# A new native _uuid module improves uuid import time and avoids using ctypes.
-		# This requires the development libuuid headers.
-		case "$version" in
-			3.4* | 3.5* | 3.6*)
-				if [[ "$v" = alpine* ]]; then
-					sed -ri -e '/util-linux-dev/d' "$dir/Dockerfile"
-				else
-					sed -ri -e '/uuid-dev/d' "$dir/Dockerfile"
-				fi
-				;;
-		esac
-
 		case "$version/$v" in
 			# https://bugs.python.org/issue32598 (Python 3.7.0b1+)
 			# TL;DR: Python 3.7+ uses OpenSSL functionality which LibreSSL 2.6.x in Alpine 3.7 doesn't implement
@@ -187,9 +174,18 @@ for version in "${versions[@]}"; do
 				;;& # (3.5*/alpine* needs to match the next block too)
 			# Libraries to build the nis module only available in Alpine 3.7+.
 			# Also require this patch https://bugs.python.org/issue32521 only available in Python 2.7, 3.6+.
-			3.4*/alpine* | 3.5*/alpine* | */alpine3.6)
+			3.[4-5]*/alpine* | */alpine3.6)
 				sed -ri -e '/libnsl-dev/d' -e '/libtirpc-dev/d' "$dir/Dockerfile"
+				;;& # (3.4*/alpine* and 3.5*/alpine* need to match the next block too)
+			# https://bugs.python.org/issue11063, https://bugs.python.org/issue20519 (Python 3.7.0+)
+			# A new native _uuid module improves uuid import time and avoids using ctypes.
+			# This requires the development libuuid headers.
+			3.[4-6]*/alpine*)
+				sed -ri -e '/util-linux-dev/d' "$dir/Dockerfile"
 				;;
+			3.[4-6]*)
+				sed -ri -e '/uuid-dev/d' "$dir/Dockerfile"
+				;;& # (other Debian variants need to match later blocks)
 			3.4/stretch*)
 				sed -ri -e 's/libssl-dev/libssl1.0-dev/g' "$dir/Dockerfile"
 				;;


### PR DESCRIPTION
Still to do:
- [x] Get this working on the non-slim Debian images
- [x] Make the update.sh code cleaner?

I'm not sure how best to do the above?

The `util-linux-dev` package was actually already being installed (as a dependency of `libtirpc-dev`) on Alpine so the native module was already being built and you can see `libuuid` as one of the final Python runtime dependencies. This makes it explicit and gets Debian to build the module as well.