### PR TITLE
Add --no-cache for all apk commands

### DIFF
--- a/2.7/alpine3.6/Dockerfile
+++ b/2.7/alpine3.6/Dockerfile
@@ -79,7 +79,7 @@ RUN set -ex \
 		| tr ',' '\n' \
 		| sort -u \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		| xargs -rt apk add --virtual .python-rundeps \
+		| xargs -rt apk add --no-cache --virtual .python-rundeps \
 	&& apk del .build-deps \
 	\
 	&& find /usr/local -depth \

--- a/2.7/alpine3.7/Dockerfile
+++ b/2.7/alpine3.7/Dockerfile
@@ -79,7 +79,7 @@ RUN set -ex \
 		| tr ',' '\n' \
 		| sort -u \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		| xargs -rt apk add --virtual .python-rundeps \
+		| xargs -rt apk add --no-cache --virtual .python-rundeps \
 	&& apk del .build-deps \
 	\
 	&& find /usr/local -depth \

--- a/2.7/alpine3.8/Dockerfile
+++ b/2.7/alpine3.8/Dockerfile
@@ -79,7 +79,7 @@ RUN set -ex \
 		| tr ',' '\n' \
 		| sort -u \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		| xargs -rt apk add --virtual .python-rundeps \
+		| xargs -rt apk add --no-cache --virtual .python-rundeps \
 	&& apk del .build-deps \
 	\
 	&& find /usr/local -depth \

--- a/3.4/alpine3.7/Dockerfile
+++ b/3.4/alpine3.7/Dockerfile
@@ -81,7 +81,7 @@ RUN set -ex \
 		| tr ',' '\n' \
 		| sort -u \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		| xargs -rt apk add --virtual .python-rundeps \
+		| xargs -rt apk add --no-cache --virtual .python-rundeps \
 	&& apk del .build-deps \
 	\
 	&& find /usr/local -depth \

--- a/3.4/alpine3.8/Dockerfile
+++ b/3.4/alpine3.8/Dockerfile
@@ -81,7 +81,7 @@ RUN set -ex \
 		| tr ',' '\n' \
 		| sort -u \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		| xargs -rt apk add --virtual .python-rundeps \
+		| xargs -rt apk add --no-cache --virtual .python-rundeps \
 	&& apk del .build-deps \
 	\
 	&& find /usr/local -depth \

--- a/3.5/alpine3.7/Dockerfile
+++ b/3.5/alpine3.7/Dockerfile
@@ -81,7 +81,7 @@ RUN set -ex \
 		| tr ',' '\n' \
 		| sort -u \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		| xargs -rt apk add --virtual .python-rundeps \
+		| xargs -rt apk add --no-cache --virtual .python-rundeps \
 	&& apk del .build-deps \
 	\
 	&& find /usr/local -depth \

--- a/3.5/alpine3.8/Dockerfile
+++ b/3.5/alpine3.8/Dockerfile
@@ -81,7 +81,7 @@ RUN set -ex \
 		| tr ',' '\n' \
 		| sort -u \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		| xargs -rt apk add --virtual .python-rundeps \
+		| xargs -rt apk add --no-cache --virtual .python-rundeps \
 	&& apk del .build-deps \
 	\
 	&& find /usr/local -depth \

--- a/3.6/alpine3.6/Dockerfile
+++ b/3.6/alpine3.6/Dockerfile
@@ -83,7 +83,7 @@ RUN set -ex \
 		| tr ',' '\n' \
 		| sort -u \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		| xargs -rt apk add --virtual .python-rundeps \
+		| xargs -rt apk add --no-cache --virtual .python-rundeps \
 	&& apk del .build-deps \
 	\
 	&& find /usr/local -depth \

--- a/3.6/alpine3.7/Dockerfile
+++ b/3.6/alpine3.7/Dockerfile
@@ -83,7 +83,7 @@ RUN set -ex \
 		| tr ',' '\n' \
 		| sort -u \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		| xargs -rt apk add --virtual .python-rundeps \
+		| xargs -rt apk add --no-cache --virtual .python-rundeps \
 	&& apk del .build-deps \
 	\
 	&& find /usr/local -depth \

--- a/3.6/alpine3.8/Dockerfile
+++ b/3.6/alpine3.8/Dockerfile
@@ -83,7 +83,7 @@ RUN set -ex \
 		| tr ',' '\n' \
 		| sort -u \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		| xargs -rt apk add --virtual .python-rundeps \
+		| xargs -rt apk add --no-cache --virtual .python-rundeps \
 	&& apk del .build-deps \
 	\
 	&& find /usr/local -depth \

--- a/3.7/alpine3.7/Dockerfile
+++ b/3.7/alpine3.7/Dockerfile
@@ -84,7 +84,7 @@ RUN set -ex \
 		| tr ',' '\n' \
 		| sort -u \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		| xargs -rt apk add --virtual .python-rundeps \
+		| xargs -rt apk add --no-cache --virtual .python-rundeps \
 	&& apk del .build-deps \
 	\
 	&& find /usr/local -depth \

--- a/3.7/alpine3.8/Dockerfile
+++ b/3.7/alpine3.8/Dockerfile
@@ -84,7 +84,7 @@ RUN set -ex \
 		| tr ',' '\n' \
 		| sort -u \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		| xargs -rt apk add --virtual .python-rundeps \
+		| xargs -rt apk add --no-cache --virtual .python-rundeps \
 	&& apk del .build-deps \
 	\
 	&& find /usr/local -depth \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -80,7 +80,7 @@ RUN set -ex \
 		| tr ',' '\n' \
 		| sort -u \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		| xargs -rt apk add --virtual .python-rundeps \
+		| xargs -rt apk add --no-cache --virtual .python-rundeps \
 	&& apk del .build-deps \
 	\
 	&& find /usr/local -depth \

--- a/Dockerfile-caveman-alpine.template
+++ b/Dockerfile-caveman-alpine.template
@@ -75,7 +75,7 @@ RUN set -ex \
 		| tr ',' '\n' \
 		| sort -u \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		| xargs -rt apk add --virtual .python-rundeps \
+		| xargs -rt apk add --no-cache --virtual .python-rundeps \
 	&& apk del .build-deps \
 	\
 	&& find /usr/local -depth \


### PR DESCRIPTION
The Alpine images contain unnecessary repository indexes in `/var/cache/apk`. The following changes were made to ensure they are not saved.

- ensure --no-cache to all `apk add` commands
- add --no-cache to all `apk del` commands. Even though it removes packages, running it will ensure that an index is present locally.