### PR TITLE
Remove unnecessary package definitions to install

### DIFF
--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -20,11 +20,8 @@ RUN set -ex \
 	\
 	&& savedAptMark="$(apt-mark showmanual)" \
 	&& apt-get update && apt-get install -y --no-install-recommends \
-		dpkg-dev \
 		gcc \
 		libbz2-dev \
-		libc6-dev \
-		libexpat1-dev \
 		libffi-dev \
 		libgdbm-dev \
 		liblzma-dev \
@@ -32,12 +29,10 @@ RUN set -ex \
 		libreadline-dev \
 		libsqlite3-dev \
 		libssl-dev \
-		make \
 		tk-dev \
 		uuid-dev \
 		wget \
 		xz-utils \
-		zlib1g-dev \
 # as of Stretch, "gpg" is no longer included by default
 		$(command -v gpg > /dev/null || echo 'gnupg dirmngr') \
 	\


### PR DESCRIPTION
the tk-dev installation includes dpkg-dev, libc6-dev,  libexpat1-dev, make and zlib1g-dev packages so their definitions are unnecessary.

It's a suggested change and more slim :).