### PR TITLE
adds USDT trace points for supported distros

### DIFF
--- a/3.4/jessie/Dockerfile
+++ b/3.4/jessie/Dockerfile
@@ -34,6 +34,8 @@ RUN set -ex \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz \
 	\
+	&& apt-get install -y --no-install-recommends systemtap-sdt-dev \
+	\
 	&& cd /usr/src/python \
 	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
@@ -43,6 +45,7 @@ RUN set -ex \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \
+		--without-dtrace \
 	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
@@ -54,6 +57,7 @@ RUN set -ex \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' + \
 	&& rm -rf /usr/src/python \
+	&& apt-get remove -y systemtap-sdt-dev \
 	\
 	&& python3 --version
 

--- a/3.4/jessie/slim/Dockerfile
+++ b/3.4/jessie/slim/Dockerfile
@@ -39,6 +39,7 @@ RUN set -ex \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		systemtap-sdt-dev \
 		tk-dev \
 		wget \
 		xz-utils \
@@ -66,6 +67,7 @@ RUN set -ex \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \
+		--with-dtrace \
 	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \

--- a/3.4/stretch/Dockerfile
+++ b/3.4/stretch/Dockerfile
@@ -36,6 +36,8 @@ RUN set -ex \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz \
 	\
+	&& apt-get install -y --no-install-recommends systemtap-sdt-dev \
+	\
 	&& cd /usr/src/python \
 	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
@@ -45,6 +47,7 @@ RUN set -ex \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \
+		--without-dtrace \
 	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
@@ -56,6 +59,7 @@ RUN set -ex \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' + \
 	&& rm -rf /usr/src/python \
+	&& apt-get remove -y systemtap-sdt-dev \
 	\
 	&& python3 --version
 

--- a/3.4/stretch/slim/Dockerfile
+++ b/3.4/stretch/slim/Dockerfile
@@ -39,6 +39,7 @@ RUN set -ex \
 		libsqlite3-dev \
 		libssl1.0-dev \
 		make \
+		systemtap-sdt-dev \
 		tk-dev \
 		wget \
 		xz-utils \
@@ -66,6 +67,7 @@ RUN set -ex \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \
+		--with-dtrace \
 	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \

--- a/3.4/wheezy/Dockerfile
+++ b/3.4/wheezy/Dockerfile
@@ -34,6 +34,8 @@ RUN set -ex \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz \
 	\
+	&& apt-get install -y --no-install-recommends systemtap-sdt-dev \
+	\
 	&& cd /usr/src/python \
 	&& gnuArch="$(dpkg-architecture -qDEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
@@ -43,6 +45,7 @@ RUN set -ex \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \
+		--without-dtrace \
 	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
@@ -54,6 +57,7 @@ RUN set -ex \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' + \
 	&& rm -rf /usr/src/python \
+	&& apt-get remove -y systemtap-sdt-dev \
 	\
 	&& python3 --version
 

--- a/3.5/jessie/Dockerfile
+++ b/3.5/jessie/Dockerfile
@@ -34,6 +34,8 @@ RUN set -ex \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz \
 	\
+	&& apt-get install -y --no-install-recommends systemtap-sdt-dev \
+	\
 	&& cd /usr/src/python \
 	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
@@ -43,6 +45,7 @@ RUN set -ex \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \
+		--without-dtrace \
 	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
@@ -54,6 +57,7 @@ RUN set -ex \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' + \
 	&& rm -rf /usr/src/python \
+	&& apt-get remove -y systemtap-sdt-dev \
 	\
 	&& python3 --version
 

--- a/3.5/jessie/slim/Dockerfile
+++ b/3.5/jessie/slim/Dockerfile
@@ -39,6 +39,7 @@ RUN set -ex \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		systemtap-sdt-dev \
 		tk-dev \
 		wget \
 		xz-utils \
@@ -66,6 +67,7 @@ RUN set -ex \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \
+		--with-dtrace \
 	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \

--- a/3.5/stretch/Dockerfile
+++ b/3.5/stretch/Dockerfile
@@ -34,6 +34,8 @@ RUN set -ex \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz \
 	\
+	&& apt-get install -y --no-install-recommends systemtap-sdt-dev \
+	\
 	&& cd /usr/src/python \
 	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
@@ -43,6 +45,7 @@ RUN set -ex \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \
+		--without-dtrace \
 	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
@@ -54,6 +57,7 @@ RUN set -ex \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' + \
 	&& rm -rf /usr/src/python \
+	&& apt-get remove -y systemtap-sdt-dev \
 	\
 	&& python3 --version
 

--- a/3.5/stretch/slim/Dockerfile
+++ b/3.5/stretch/slim/Dockerfile
@@ -39,6 +39,7 @@ RUN set -ex \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		systemtap-sdt-dev \
 		tk-dev \
 		wget \
 		xz-utils \
@@ -66,6 +67,7 @@ RUN set -ex \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \
+		--with-dtrace \
 	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \

--- a/3.6/jessie/Dockerfile
+++ b/3.6/jessie/Dockerfile
@@ -34,6 +34,8 @@ RUN set -ex \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz \
 	\
+	&& apt-get install -y --no-install-recommends systemtap-sdt-dev \
+	\
 	&& cd /usr/src/python \
 	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
@@ -43,6 +45,7 @@ RUN set -ex \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \
+		--without-dtrace \
 	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
@@ -54,6 +57,7 @@ RUN set -ex \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' + \
 	&& rm -rf /usr/src/python \
+	&& apt-get remove -y systemtap-sdt-dev \
 	\
 	&& python3 --version
 

--- a/3.6/jessie/slim/Dockerfile
+++ b/3.6/jessie/slim/Dockerfile
@@ -39,6 +39,7 @@ RUN set -ex \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		systemtap-sdt-dev \
 		tk-dev \
 		wget \
 		xz-utils \
@@ -66,6 +67,7 @@ RUN set -ex \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \
+		--with-dtrace \
 	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \

--- a/3.6/stretch/Dockerfile
+++ b/3.6/stretch/Dockerfile
@@ -34,6 +34,8 @@ RUN set -ex \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz \
 	\
+	&& apt-get install -y --no-install-recommends systemtap-sdt-dev \
+	\
 	&& cd /usr/src/python \
 	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
@@ -43,6 +45,7 @@ RUN set -ex \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \
+		--without-dtrace \
 	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
@@ -54,6 +57,7 @@ RUN set -ex \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' + \
 	&& rm -rf /usr/src/python \
+	&& apt-get remove -y systemtap-sdt-dev \
 	\
 	&& python3 --version
 

--- a/3.6/stretch/slim/Dockerfile
+++ b/3.6/stretch/slim/Dockerfile
@@ -39,6 +39,7 @@ RUN set -ex \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		systemtap-sdt-dev \
 		tk-dev \
 		wget \
 		xz-utils \
@@ -66,6 +67,7 @@ RUN set -ex \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \
+		--with-dtrace \
 	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \

--- a/3.7/stretch/Dockerfile
+++ b/3.7/stretch/Dockerfile
@@ -35,6 +35,8 @@ RUN set -ex \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz \
 	\
+	&& apt-get install -y --no-install-recommends systemtap-sdt-dev \
+	\
 	&& cd /usr/src/python \
 	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
@@ -44,6 +46,7 @@ RUN set -ex \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \
+		--without-dtrace \
 	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
@@ -55,6 +58,7 @@ RUN set -ex \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' + \
 	&& rm -rf /usr/src/python \
+	&& apt-get remove -y systemtap-sdt-dev \
 	\
 	&& python3 --version
 

--- a/3.7/stretch/slim/Dockerfile
+++ b/3.7/stretch/slim/Dockerfile
@@ -39,6 +39,7 @@ RUN set -ex \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		systemtap-sdt-dev \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -67,6 +68,7 @@ RUN set -ex \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \
+		--with-dtrace \
 	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -31,6 +31,8 @@ RUN set -ex \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz \
 	\
+	&& apt-get install -y --no-install-recommends systemtap-sdt-dev \
+	\
 	&& cd /usr/src/python \
 	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
@@ -40,6 +42,7 @@ RUN set -ex \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \
+		--without-dtrace \
 	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
@@ -51,6 +54,7 @@ RUN set -ex \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' + \
 	&& rm -rf /usr/src/python \
+	&& apt-get remove -y systemtap-sdt-dev \
 	\
 	&& python3 --version
 

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -33,6 +33,7 @@ RUN set -ex \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		systemtap-sdt-dev \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -61,6 +62,7 @@ RUN set -ex \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \
+		--with-dtrace \
 	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \


### PR DESCRIPTION
Python supports user-level statically defined tracing (USDT) for platforms that support it. This has historically been not compiled-in by default in Linux distributions because only hosts with `systemtap` can take advantage of it. Newer Linux kernels  (including all kernels supported by Docker) have eBPF, and this allows for all users to take advantage of tools like [pythonflow](https://github.com/iovisor/bcc/blob/master/tools/pythonflow.sh), [pythongc](https://github.com/iovisor/bcc/blob/master/tools/pythongc.sh), etc. Including this option would have the happy side-effect of allowing for the USDT probes to be used for DTrace on platforms where Docker containers can be run on Illumos (ex. Joyent's Triton).

The upstream implementation is a little weird (ref https://docs.python.org/3/howto/instrumentation.html). The `--with-dtrace` flag expects the `dtrace` binary to exist so that appropriate header files can be written. The `systemtap-sdt-dev` package for Debian provides a mock "`dtrace` binary" (actually a Python script) which can generate the header files.

This package or one like it is not available for Alpine. I have [another branch](https://github.com/tgross/docker-python/pull/2) with an experiment to vendor the header files and the mock `dtrace` binary from the Debian `systemtap-sdt-dev` package. This works inasmuch as the header gets created and I've verified the USDT probes work, but it's a totally gross approach and perhaps dubious from a licensing standpoint so I didn't include it in this PR. But I'd love to have a discussion about what the preferred approach would be.
