### PR TITLE
KM-376 built a debug version of the python-3.6 docker imnage, on whic…

### DIFF
--- a/3.6/buster/slim/Dockerfile
+++ b/3.6/buster/slim/Dockerfile
@@ -39,6 +39,7 @@ RUN set -ex \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		systemtap-sdt-dev \
 		tk-dev \
 		wget \
 		xz-utils \
@@ -67,6 +68,8 @@ RUN set -ex \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \
+		--with-pydebug \
+		--with-dtrace \
 	&& make -j "$(nproc)" \
 # setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
 		PROFILE_TASK='-m test.regrtest --pgo \


### PR DESCRIPTION
…h we rely, so that we can use debugging tools in docker containers. First commit, not yet proven. See https://blog.0x74696d.com/posts/debugging-python-containers-in-production/.