### PR TITLE
Add windowsservercore-1809 to AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,16 +1,31 @@
 version: build-{build}.{branch}
-image: Visual Studio 2017
 
 environment:
   matrix:
     - version: 3.9-rc
       variant: windowsservercore-ltsc2016
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - version: 3.9-rc
+      variant: windowsservercore-1809
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     - version: 3.8
       variant: windowsservercore-ltsc2016
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - version: 3.8
+      variant: windowsservercore-1809
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     - version: 3.7
       variant: windowsservercore-ltsc2016
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - version: 3.7
+      variant: windowsservercore-1809
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     - version: 2.7
       variant: windowsservercore-ltsc2016
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - version: 2.7
+      variant: windowsservercore-1809
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
 
 install:
   - ps: |

--- a/update.sh
+++ b/update.sh
@@ -187,10 +187,12 @@ for version in "${versions[@]}"; do
 		fi
 
 		case "$v" in
-			windows/*-1809) ;; # no AppVeyor support for 1809 yet: https://github.com/appveyor/ci/issues/1885 and https://github.com/appveyor/ci/issues/2676
-
-			windows/*)
-				appveyorEnv='\n    - version: '"$version"'\n      variant: '"$variant$appveyorEnv"
+			# https://www.appveyor.com/docs/windows-images-software/
+			windows/*-1809)
+				appveyorEnv='\n    - version: '"$version"'\n      variant: '"$variant"'\n      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019'"$appveyorEnv"
+				;;
+			windows/*-ltsc2016)
+				appveyorEnv='\n    - version: '"$version"'\n      variant: '"$variant"'\n      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017'"$appveyorEnv"
 				;;
 
 			*)


### PR DESCRIPTION
current update.sh is lacking the latest windowsservercore version which is 1909