### PR TITLE
Set PYTHONIOENCODING for python-windowsservercore

### DIFF
--- a/3.10-rc/windows/windowsservercore-1809/Dockerfile
+++ b/3.10-rc/windows/windowsservercore-1809/Dockerfile
@@ -8,6 +8,9 @@ FROM mcr.microsoft.com/windows/servercore:1809
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# https://github.com/docker-library/python/pull/557
+ENV PYTHONIOENCODING UTF-8
+
 ENV PYTHON_VERSION 3.10.0a1
 ENV PYTHON_RELEASE 3.10.0
 

--- a/3.10-rc/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/3.10-rc/windows/windowsservercore-ltsc2016/Dockerfile
@@ -8,6 +8,9 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# https://github.com/docker-library/python/pull/557
+ENV PYTHONIOENCODING UTF-8
+
 ENV PYTHON_VERSION 3.10.0a1
 ENV PYTHON_RELEASE 3.10.0
 

--- a/3.7/windows/windowsservercore-1809/Dockerfile
+++ b/3.7/windows/windowsservercore-1809/Dockerfile
@@ -8,6 +8,9 @@ FROM mcr.microsoft.com/windows/servercore:1809
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# https://github.com/docker-library/python/pull/557
+ENV PYTHONIOENCODING UTF-8
+
 ENV PYTHON_VERSION 3.7.9
 ENV PYTHON_RELEASE 3.7.9
 

--- a/3.7/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/3.7/windows/windowsservercore-ltsc2016/Dockerfile
@@ -8,6 +8,9 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# https://github.com/docker-library/python/pull/557
+ENV PYTHONIOENCODING UTF-8
+
 ENV PYTHON_VERSION 3.7.9
 ENV PYTHON_RELEASE 3.7.9
 

--- a/3.8/windows/windowsservercore-1809/Dockerfile
+++ b/3.8/windows/windowsservercore-1809/Dockerfile
@@ -8,6 +8,9 @@ FROM mcr.microsoft.com/windows/servercore:1809
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# https://github.com/docker-library/python/pull/557
+ENV PYTHONIOENCODING UTF-8
+
 ENV PYTHON_VERSION 3.8.6
 ENV PYTHON_RELEASE 3.8.6
 

--- a/3.8/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/3.8/windows/windowsservercore-ltsc2016/Dockerfile
@@ -8,6 +8,9 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# https://github.com/docker-library/python/pull/557
+ENV PYTHONIOENCODING UTF-8
+
 ENV PYTHON_VERSION 3.8.6
 ENV PYTHON_RELEASE 3.8.6
 

--- a/3.9/windows/windowsservercore-1809/Dockerfile
+++ b/3.9/windows/windowsservercore-1809/Dockerfile
@@ -8,6 +8,9 @@ FROM mcr.microsoft.com/windows/servercore:1809
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# https://github.com/docker-library/python/pull/557
+ENV PYTHONIOENCODING UTF-8
+
 ENV PYTHON_VERSION 3.9.0
 ENV PYTHON_RELEASE 3.9.0
 

--- a/3.9/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/3.9/windows/windowsservercore-ltsc2016/Dockerfile
@@ -8,6 +8,9 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# https://github.com/docker-library/python/pull/557
+ENV PYTHONIOENCODING UTF-8
+
 ENV PYTHON_VERSION 3.9.0
 ENV PYTHON_RELEASE 3.9.0
 

--- a/Dockerfile-windowsservercore.template
+++ b/Dockerfile-windowsservercore.template
@@ -2,6 +2,9 @@ FROM mcr.microsoft.com/windows/servercore:%%PLACEHOLDER%%
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# https://github.com/docker-library/python/pull/557
+ENV PYTHONIOENCODING UTF-8
+
 ENV PYTHON_VERSION %%PLACEHOLDER%%
 ENV PYTHON_RELEASE %%PLACEHOLDER%%
 


### PR DESCRIPTION
Related #147 

I'm using `python:3.8-windowsservercore-1809` image.
When I try to print a Unicode character in docker container without --tty, I get an error like this:

```
UnicodeEncodeError: 'charmap' codec can't encode characters in position 0-2: character maps to <undefined>
```

