### PR TITLE
Removing LANG env var from 3.10-rc and templates

### DIFF
--- a/3.10/alpine3.14/Dockerfile
+++ b/3.10/alpine3.14/Dockerfile
@@ -9,10 +9,6 @@ FROM alpine:3.14
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apk add --no-cache \

--- a/3.10/alpine3.15/Dockerfile
+++ b/3.10/alpine3.15/Dockerfile
@@ -9,10 +9,6 @@ FROM alpine:3.15
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apk add --no-cache \

--- a/3.10/bullseye/Dockerfile
+++ b/3.10/bullseye/Dockerfile
@@ -9,10 +9,6 @@ FROM buildpack-deps:bullseye
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/3.10/buster/Dockerfile
+++ b/3.10/buster/Dockerfile
@@ -9,10 +9,6 @@ FROM buildpack-deps:buster
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/3.10/slim-bullseye/Dockerfile
+++ b/3.10/slim-bullseye/Dockerfile
@@ -9,10 +9,6 @@ FROM debian:bullseye-slim
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/3.10/slim-buster/Dockerfile
+++ b/3.10/slim-buster/Dockerfile
@@ -9,10 +9,6 @@ FROM debian:buster-slim
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/3.11-rc/alpine3.14/Dockerfile
+++ b/3.11-rc/alpine3.14/Dockerfile
@@ -9,10 +9,6 @@ FROM alpine:3.14
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apk add --no-cache \

--- a/3.11-rc/alpine3.15/Dockerfile
+++ b/3.11-rc/alpine3.15/Dockerfile
@@ -9,10 +9,6 @@ FROM alpine:3.15
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apk add --no-cache \

--- a/3.11-rc/bullseye/Dockerfile
+++ b/3.11-rc/bullseye/Dockerfile
@@ -9,10 +9,6 @@ FROM buildpack-deps:bullseye
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/3.11-rc/buster/Dockerfile
+++ b/3.11-rc/buster/Dockerfile
@@ -9,10 +9,6 @@ FROM buildpack-deps:buster
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/3.11-rc/slim-bullseye/Dockerfile
+++ b/3.11-rc/slim-bullseye/Dockerfile
@@ -9,10 +9,6 @@ FROM debian:bullseye-slim
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/3.11-rc/slim-buster/Dockerfile
+++ b/3.11-rc/slim-buster/Dockerfile
@@ -9,10 +9,6 @@ FROM debian:buster-slim
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/3.7/alpine3.14/Dockerfile
+++ b/3.7/alpine3.14/Dockerfile
@@ -9,10 +9,6 @@ FROM alpine:3.14
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apk add --no-cache \

--- a/3.7/alpine3.15/Dockerfile
+++ b/3.7/alpine3.15/Dockerfile
@@ -9,10 +9,6 @@ FROM alpine:3.15
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apk add --no-cache \

--- a/3.7/bullseye/Dockerfile
+++ b/3.7/bullseye/Dockerfile
@@ -9,10 +9,6 @@ FROM buildpack-deps:bullseye
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/3.7/buster/Dockerfile
+++ b/3.7/buster/Dockerfile
@@ -9,10 +9,6 @@ FROM buildpack-deps:buster
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/3.7/slim-bullseye/Dockerfile
+++ b/3.7/slim-bullseye/Dockerfile
@@ -9,10 +9,6 @@ FROM debian:bullseye-slim
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/3.7/slim-buster/Dockerfile
+++ b/3.7/slim-buster/Dockerfile
@@ -9,10 +9,6 @@ FROM debian:buster-slim
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/3.8/alpine3.14/Dockerfile
+++ b/3.8/alpine3.14/Dockerfile
@@ -9,10 +9,6 @@ FROM alpine:3.14
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apk add --no-cache \

--- a/3.8/alpine3.15/Dockerfile
+++ b/3.8/alpine3.15/Dockerfile
@@ -9,10 +9,6 @@ FROM alpine:3.15
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apk add --no-cache \

--- a/3.8/bullseye/Dockerfile
+++ b/3.8/bullseye/Dockerfile
@@ -9,10 +9,6 @@ FROM buildpack-deps:bullseye
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/3.8/buster/Dockerfile
+++ b/3.8/buster/Dockerfile
@@ -9,10 +9,6 @@ FROM buildpack-deps:buster
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/3.8/slim-bullseye/Dockerfile
+++ b/3.8/slim-bullseye/Dockerfile
@@ -9,10 +9,6 @@ FROM debian:bullseye-slim
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/3.8/slim-buster/Dockerfile
+++ b/3.8/slim-buster/Dockerfile
@@ -9,10 +9,6 @@ FROM debian:buster-slim
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/3.9/alpine3.14/Dockerfile
+++ b/3.9/alpine3.14/Dockerfile
@@ -9,10 +9,6 @@ FROM alpine:3.14
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apk add --no-cache \

--- a/3.9/alpine3.15/Dockerfile
+++ b/3.9/alpine3.15/Dockerfile
@@ -9,10 +9,6 @@ FROM alpine:3.15
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apk add --no-cache \

--- a/3.9/bullseye/Dockerfile
+++ b/3.9/bullseye/Dockerfile
@@ -9,10 +9,6 @@ FROM buildpack-deps:bullseye
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/3.9/buster/Dockerfile
+++ b/3.9/buster/Dockerfile
@@ -9,10 +9,6 @@ FROM buildpack-deps:buster
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/3.9/slim-bullseye/Dockerfile
+++ b/3.9/slim-bullseye/Dockerfile
@@ -9,10 +9,6 @@ FROM debian:bullseye-slim
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/3.9/slim-buster/Dockerfile
+++ b/3.9/slim-buster/Dockerfile
@@ -9,10 +9,6 @@ FROM debian:buster-slim
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -19,10 +19,6 @@ FROM buildpack-deps:{{ env.variant }}
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
 # runtime dependencies
 {{ if is_alpine then ( -}}
 RUN set -eux; \


### PR DESCRIPTION
Since `ENV LANG C.UTF-8` is apparently [no longer necessary](https://bugs.python.org/issue19846), removed those from 3.10-rc and templates not to cause confusion.