### PR TITLE
update pypa/get-pip branch from master -> main

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -34,7 +34,7 @@ fi
 versions=( "${versions[@]%/}" )
 
 pipVersion="$(curl -fsSL 'https://pypi.org/pypi/pip/json' | jq -r .info.version)"
-getPipCommit="$(curl -fsSL 'https://github.com/pypa/get-pip/commits/master/get-pip.py.atom' | tac|tac | awk -F '[[:space:]]*[<>/]+' '$2 == "id" && $3 ~ /Commit/ { print $4; exit }')"
+getPipCommit="$(curl -fsSL 'https://github.com/pypa/get-pip/commits/main/get-pip.py.atom' | tac|tac | awk -F '[[:space:]]*[<>/]+' '$2 == "id" && $3 ~ /Commit/ { print $4; exit }')"
 getPipUrl="https://github.com/pypa/get-pip/raw/$getPipCommit/get-pip.py"
 getPipSha256="$(curl -fsSL "$getPipUrl" | sha256sum | cut -d' ' -f1)"
 


### PR DESCRIPTION
It looks like https://github.com/pypa/get-pip/ updated their default branch from `master` to `main` and deleted the master branch, so this updates the update script accordingly so that it doesn't get a 404