### PR TITLE
Avoid wasted space in /var/cache/

### DIFF
--- a/3.10-rc/buster/Dockerfile
+++ b/3.10-rc/buster/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libbluetooth-dev \
 		tk-dev \
 		uuid-dev \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/cache/*
 
 ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
 ENV PYTHON_VERSION 3.10.0a6

--- a/3.10-rc/buster/slim/Dockerfile
+++ b/3.10-rc/buster/slim/Dockerfile
@@ -21,7 +21,8 @@ RUN set -eux; \
 		netbase \
 		tzdata \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/*; \
+	rm -rf /var/cache/*
 
 ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
 ENV PYTHON_VERSION 3.10.0a6
@@ -98,6 +99,7 @@ RUN set -ex \
 		| xargs -r apt-mark manual \
 	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/cache/* \
 	\
 	&& python3 --version
 
@@ -127,6 +129,7 @@ RUN set -ex; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+	rm -rf /var/cache/*; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/3.6/buster/Dockerfile
+++ b/3.6/buster/Dockerfile
@@ -17,7 +17,8 @@ ENV LANG C.UTF-8
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		libbluetooth-dev \
 		tk-dev \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/cache/*
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.6.13

--- a/3.6/buster/slim/Dockerfile
+++ b/3.6/buster/slim/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 		ca-certificates \
 		netbase \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/*; \
+	rm -rf /var/cache/*
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.6.13
@@ -133,6 +134,7 @@ RUN set -ex \
 		| xargs -r apt-mark manual \
 	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/cache/* \
 	\
 	&& python3 --version
 
@@ -162,6 +164,7 @@ RUN set -ex; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+	rm -rf /var/cache/*; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/3.6/stretch/Dockerfile
+++ b/3.6/stretch/Dockerfile
@@ -17,7 +17,8 @@ ENV LANG C.UTF-8
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		libbluetooth-dev \
 		tk-dev \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/cache/*
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.6.13

--- a/3.6/stretch/slim/Dockerfile
+++ b/3.6/stretch/slim/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 		ca-certificates \
 		netbase \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/*; \
+	rm -rf /var/cache/*
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.6.13
@@ -133,6 +134,7 @@ RUN set -ex \
 		| xargs -r apt-mark manual \
 	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/cache/* \
 	\
 	&& python3 --version
 
@@ -162,6 +164,7 @@ RUN set -ex; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+	rm -rf /var/cache/*; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/3.7/buster/Dockerfile
+++ b/3.7/buster/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libbluetooth-dev \
 		tk-dev \
 		uuid-dev \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/cache/*
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.7.10

--- a/3.7/buster/slim/Dockerfile
+++ b/3.7/buster/slim/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 		ca-certificates \
 		netbase \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/*; \
+	rm -rf /var/cache/*
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.7.10
@@ -134,6 +135,7 @@ RUN set -ex \
 		| xargs -r apt-mark manual \
 	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/cache/* \
 	\
 	&& python3 --version
 
@@ -163,6 +165,7 @@ RUN set -ex; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+	rm -rf /var/cache/*; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/3.7/stretch/Dockerfile
+++ b/3.7/stretch/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libbluetooth-dev \
 		tk-dev \
 		uuid-dev \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/cache/*
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.7.10

--- a/3.7/stretch/slim/Dockerfile
+++ b/3.7/stretch/slim/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 		ca-certificates \
 		netbase \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/*; \
+	rm -rf /var/cache/*;
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.7.10
@@ -134,6 +135,7 @@ RUN set -ex \
 		| xargs -r apt-mark manual \
 	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/cache/* \
 	\
 	&& python3 --version
 
@@ -163,6 +165,7 @@ RUN set -ex; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+	rm -rf /var/cache/*; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/3.8/buster/Dockerfile
+++ b/3.8/buster/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libbluetooth-dev \
 		tk-dev \
 		uuid-dev \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/cache/*
 
 ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568
 ENV PYTHON_VERSION 3.8.8

--- a/3.8/buster/slim/Dockerfile
+++ b/3.8/buster/slim/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 		ca-certificates \
 		netbase \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/*; \
+	rm -rf /var/cache/*
 
 ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568
 ENV PYTHON_VERSION 3.8.8
@@ -98,6 +99,7 @@ RUN set -ex \
 		| xargs -r apt-mark manual \
 	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/cache/* \
 	\
 	&& python3 --version
 
@@ -127,6 +129,7 @@ RUN set -ex; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+	rm -rf /var/cache/*; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/3.9/buster/Dockerfile
+++ b/3.9/buster/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libbluetooth-dev \
 		tk-dev \
 		uuid-dev \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/cache/*
 
 ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568
 ENV PYTHON_VERSION 3.9.2

--- a/3.9/buster/slim/Dockerfile
+++ b/3.9/buster/slim/Dockerfile
@@ -21,7 +21,8 @@ RUN set -eux; \
 		netbase \
 		tzdata \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/*; \
+	rm -rf /var/cache/*
 
 ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568
 ENV PYTHON_VERSION 3.9.2
@@ -98,6 +99,7 @@ RUN set -ex \
 		| xargs -r apt-mark manual \
 	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/cache/* \
 	\
 	&& python3 --version
 
@@ -127,6 +129,7 @@ RUN set -ex; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+	rm -rf /var/cache/*; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -12,7 +12,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libbluetooth-dev \
 		tk-dev \
 		uuid-dev \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/cache/*
 
 ENV GPG_KEY %%PLACEHOLDER%%
 ENV PYTHON_VERSION %%PLACEHOLDER%%

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -15,7 +15,8 @@ RUN set -eux; \
 		netbase \
 		tzdata \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/*; \
+	rm -rf /var/cache/*
 
 ENV GPG_KEY %%PLACEHOLDER%%
 ENV PYTHON_VERSION %%PLACEHOLDER%%
@@ -129,6 +130,7 @@ RUN set -ex \
 		| xargs -r apt-mark manual \
 	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/cache/* \
 	\
 	&& python3 --version
 
@@ -158,6 +160,7 @@ RUN set -ex; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+	rm -rf /var/cache/*; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \


### PR DESCRIPTION
Hello,
Long time lurker, first time PRer.

Today we were building an image `FROM python:3-slim` and there was a non insignificant amount of data that was being leaked in a layer upstream.
With the help of our OCD and [`dive`](https://github.com/wagoodman/dive/) we figured out what it was.

And instead of opening an issue, we're opening a PR with a proposed solution.
```
$ docker images python:3.9-slim 
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
python              3.9-slim            b5770c0ad1d2        3 days ago          114MB

$ CI=true dive python:3.9-slim | head -n 20
  Using default CI config
Image Source: docker://python:3.9-slim
Fetching image... (this can take a while for large images)
Analyzing image...
  efficiency: 95.6723 %
  wastedBytes: 6587148 bytes (6.6 MB)
  userWastedPercent: 14.5778 %
Inefficient Files:
Count  Wasted Space  File Path
    4        3.1 MB  /var/cache/debconf/templates.dat
    3        2.3 MB  /var/cache/debconf/templates.dat-old
    4        322 kB  /var/lib/dpkg/status
    4        322 kB  /var/lib/dpkg/status-old
    3        240 kB  /var/log/dpkg.log
    3         92 kB  /var/log/apt/term.log
    4         54 kB  /var/cache/debconf/config.dat
    4         29 kB  /etc/ld.so.cache
    4         28 kB  /var/log/apt/eipp.log.xz
    3         26 kB  /var/cache/debconf/config.dat-old
    3         21 kB  /var/log/apt/history.log
...
```

This PR keeps the /var/cache/ clean along with the `apt` cleanups.
So we end up with an image with the following size

```
$ docker images python:3-extra-slim
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
python              3-extra-slim        25a9aec80e53        57 seconds ago      110MB

$ CI=true dive python:3-extra-slim | head -n 20
  Using default CI config
Image Source: docker://python:3-extra-slim
Fetching image... (this can take a while for large images)
Analyzing image...
  efficiency: 99.1972 %
  wastedBytes: 1072807 bytes (1.1 MB)
  userWastedPercent: 2.6087 %
Inefficient Files:
Count  Wasted Space  File Path
    4        322 kB  /var/lib/dpkg/status
    4        322 kB  /var/lib/dpkg/status-old
    3        240 kB  /var/log/dpkg.log
    3         92 kB  /var/log/apt/term.log
    4         29 kB  /etc/ld.so.cache
    4         28 kB  /var/log/apt/eipp.log.xz
    3         21 kB  /var/log/apt/history.log
    4         19 kB  /var/lib/apt/extended_states
    2         423 B  /root/.wget-hsts
    4           0 B  /var/lib/dpkg/lock
    2           0 B  /var/lib/dpkg/triggers/Unincorp
...
```

According to [the linux foundation](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s05.html):
> Files located under /var/cache may be expired in an application specific manner, by the system administrator, or both. The application must always be able to recover from manual deletion of these files (generally because of a disk space shortage). No other requirements are made on the data format of the cache directories.

If we want to go one step further there is still more things to cleanup.
The logs could go, as well as `/var/lib/dpkg/status-old`.

So it should be theoretically safe to do this, but it may have some consequences for downstream images that I can't foresee.