### PR TITLE
Fix "SSLError"

### DIFF
--- a/3.8/buster/Dockerfile
+++ b/3.8/buster/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libbluetooth-dev \
 		tk-dev \
 		uuid-dev \
+		libssl-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568


### PR DESCRIPTION
without "apt-get install libssl-dev" before compiling python:
pip is configured with locations that require TLS/SSL, however the ssl module in Python is not available.