### PR TITLE
docker build fails for alpine running behind proxy

### DIFF
--- a/3.9/alpine3.14/Dockerfile
+++ b/3.9/alpine3.14/Dockerfile
@@ -20,6 +20,9 @@ RUN set -eux; \
 		ca-certificates \
 # and tzdata for PEP 615 (https://www.python.org/dev/peps/pep-0615/)
 		tzdata \
+# adding wget from apk, since busybox wget fails behind a proxy
+# https://gitlab.alpinelinux.org/alpine/aports/-/issues/10446
+		wget \
 	;
 # other runtime dependencies for Python are installed later
 


### PR DESCRIPTION
https://github.com/docker-library/python/issues/630

This is because of issue with busybox linux that comes default 
see https://gitlab.alpinelinux.org/alpine/aports/-/issues/10446

The proposed solution is to override busybox wget with wget from apk.
'apk add wget'