### PR TITLE
Add Windows Server 2022 images for 3.9 and 3.10-rc

### DIFF
--- a/3.10-rc/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/3.10-rc/windows/windowsservercore-ltsc2022/Dockerfile
@@ -1,0 +1,82 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# https://github.com/docker-library/python/pull/557
+ENV PYTHONIOENCODING UTF-8
+
+ENV PYTHON_VERSION 3.10.0rc1
+ENV PYTHON_RELEASE 3.10.0
+
+RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env:PYTHON_RELEASE, $env:PYTHON_VERSION); \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $url -OutFile 'python.exe'; \
+	\
+	Write-Host 'Installing ...'; \
+# https://docs.python.org/3/using/windows.html#installing-without-ui
+	$exitCode = (Start-Process python.exe -Wait -NoNewWindow -PassThru \
+		-ArgumentList @( \
+			'/quiet', \
+			'InstallAllUsers=1', \
+			'TargetDir=C:\Python', \
+			'PrependPath=1', \
+			'Shortcuts=0', \
+			'Include_doc=0', \
+			'Include_pip=0', \
+			'Include_test=0' \
+		) \
+	).ExitCode; \
+	if ($exitCode -ne 0) { \
+		Write-Host ('Running python installer failed with exit code: {0}' -f $exitCode); \
+		Get-ChildItem $env:TEMP | Sort-Object -Descending -Property LastWriteTime | Select-Object -First 1 | Get-Content; \
+		exit $exitCode; \
+	} \
+	\
+# the installer updated PATH, so we should refresh our local value
+	$env:PATH = [Environment]::GetEnvironmentVariable('PATH', [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  python --version'; python --version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item python.exe -Force; \
+	Remove-Item $env:TEMP/Python*.log -Force; \
+	\
+	Write-Host 'Complete.'
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 21.2.4
+# https://github.com/pypa/get-pip
+ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/c20b0cfd643cd4a19246ccf204e2997af70f6b21/public/get-pip.py
+ENV PYTHON_GET_PIP_SHA256 fa6f3fb93cce234cd4e8dd2beb54a51ab9c247653b52855a48dd44e6b21ff28b
+
+RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:PYTHON_GET_PIP_URL -OutFile 'get-pip.py'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:PYTHON_GET_PIP_SHA256); \
+	if ((Get-FileHash 'get-pip.py' -Algorithm sha256).Hash -ne $env:PYTHON_GET_PIP_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host ('Installing pip=={0} ...' -f $env:PYTHON_PIP_VERSION); \
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		('pip=={0}' -f $env:PYTHON_PIP_VERSION) \
+	; \
+	Remove-Item get-pip.py -Force; \
+	\
+	Write-Host 'Verifying pip install ...'; \
+	pip --version; \
+	\
+	Write-Host 'Complete.'
+
+CMD ["python"]

--- a/3.9/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/3.9/windows/windowsservercore-ltsc2022/Dockerfile
@@ -1,0 +1,82 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# https://github.com/docker-library/python/pull/557
+ENV PYTHONIOENCODING UTF-8
+
+ENV PYTHON_VERSION 3.9.6
+ENV PYTHON_RELEASE 3.9.6
+
+RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env:PYTHON_RELEASE, $env:PYTHON_VERSION); \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $url -OutFile 'python.exe'; \
+	\
+	Write-Host 'Installing ...'; \
+# https://docs.python.org/3/using/windows.html#installing-without-ui
+	$exitCode = (Start-Process python.exe -Wait -NoNewWindow -PassThru \
+		-ArgumentList @( \
+			'/quiet', \
+			'InstallAllUsers=1', \
+			'TargetDir=C:\Python', \
+			'PrependPath=1', \
+			'Shortcuts=0', \
+			'Include_doc=0', \
+			'Include_pip=0', \
+			'Include_test=0' \
+		) \
+	).ExitCode; \
+	if ($exitCode -ne 0) { \
+		Write-Host ('Running python installer failed with exit code: {0}' -f $exitCode); \
+		Get-ChildItem $env:TEMP | Sort-Object -Descending -Property LastWriteTime | Select-Object -First 1 | Get-Content; \
+		exit $exitCode; \
+	} \
+	\
+# the installer updated PATH, so we should refresh our local value
+	$env:PATH = [Environment]::GetEnvironmentVariable('PATH', [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  python --version'; python --version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item python.exe -Force; \
+	Remove-Item $env:TEMP/Python*.log -Force; \
+	\
+	Write-Host 'Complete.'
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 21.2.4
+# https://github.com/pypa/get-pip
+ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/c20b0cfd643cd4a19246ccf204e2997af70f6b21/public/get-pip.py
+ENV PYTHON_GET_PIP_SHA256 fa6f3fb93cce234cd4e8dd2beb54a51ab9c247653b52855a48dd44e6b21ff28b
+
+RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:PYTHON_GET_PIP_URL -OutFile 'get-pip.py'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:PYTHON_GET_PIP_SHA256); \
+	if ((Get-FileHash 'get-pip.py' -Algorithm sha256).Hash -ne $env:PYTHON_GET_PIP_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host ('Installing pip=={0} ...' -f $env:PYTHON_PIP_VERSION); \
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		('pip=={0}' -f $env:PYTHON_PIP_VERSION) \
+	; \
+	Remove-Item get-pip.py -Force; \
+	\
+	Write-Host 'Verifying pip install ...'; \
+	pip --version; \
+	\
+	Write-Host 'Complete.'
+
+CMD ["python"]

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -80,7 +80,7 @@ for version in "${versions[@]}"; do
 	for v in \
 		{bullseye,buster}{,/slim} \
 		alpine{3.14,3.13} \
-		windows/windowsservercore-{1809,ltsc2016} \
+		windows/windowsservercore-{ltsc2022,1809,ltsc2016} \
 	; do
 		dir="$version/$v"
 		variant="$(basename "$v")"

--- a/update.sh
+++ b/update.sh
@@ -134,7 +134,7 @@ for version in "${versions[@]}"; do
 	for v in \
 		alpine{3.14,3.13} \
 		{buster,bullseye}{/slim,} \
-		windows/windowsservercore-{1809,ltsc2016} \
+		windows/windowsservercore-{ltsc2022,1809,ltsc2016} \
 	; do
 		dir="$version/$v"
 		variant="$(basename "$v")"


### PR DESCRIPTION
Tested on a Windows Server 2022 evaluation install in a Hyper-V VM, using [Mirantis Container Runtime 20.10.6 from `DockerMsftProvider`](https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=Windows-Server).

Basic tests for functionality, for both new Dockerfiles, downloaded into otherwise-empty directories:
```
PS C:\Users\Administrator\3.9> docker build . -t py39
Sending build context to Docker daemon  4.608kB
Step 1/11 : FROM mcr.microsoft.com/windows/servercore:ltsc2022
...
Successfully tagged py39:latest
PS C:\Users\Administrator\3.9> docker run py39 python -c "import platform; print(platform.win32_ver()); import sys; print(sys.version)"
('10', '10.0.20348', 'SP0', 'Multiprocessor Free')
3.9.6 (tags/v3.9.6:db3ff76, Jun 28 2021, 15:26:21) [MSC v.1929 64 bit (AMD64)]
```

```
PS C:\Users\Administrator\3.10-rc> docker build . -t py310rc
Sending build context to Docker daemon  4.608kB
Step 1/11 : FROM mcr.microsoft.com/windows/servercore:ltsc2022
...
Successfully tagged py310rc:latest
PS C:\Users\Administrator\3.10-rc> docker run py310rc python -c "import platform; print(platform.win32_ver()); import sys; print(sys.version)"
('10', '10.0.20348', 'SP0', 'Multiprocessor Free')
3.10.0rc1 (tags/v3.10.0rc1:cc115e5, Aug  3 2021, 15:22:01) [MSC v.1929 64 bit (AMD64)]
```

- [x] Test the images (~~either CI-generated, or~~ just run the Dockerfiles locally)
- [x] Internal sign-off per Wargaming.net Open Source contribution policy (2/2 done)