### PR TITLE
Fix #501: add --with-lto to 3.10 and newer

### DIFF
--- a/3.10/alpine3.13/Dockerfile
+++ b/3.10/alpine3.13/Dockerfile
@@ -80,6 +80,7 @@ RUN set -ex \
 		--enable-optimizations \
 		--enable-option-checking=fatal \
 		--enable-shared \
+		--with-lto \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \

--- a/3.10/alpine3.14/Dockerfile
+++ b/3.10/alpine3.14/Dockerfile
@@ -80,6 +80,7 @@ RUN set -ex \
 		--enable-optimizations \
 		--enable-option-checking=fatal \
 		--enable-shared \
+		--with-lto \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \

--- a/3.10/bullseye/Dockerfile
+++ b/3.10/bullseye/Dockerfile
@@ -44,6 +44,7 @@ RUN set -ex \
 		--enable-optimizations \
 		--enable-option-checking=fatal \
 		--enable-shared \
+		--with-lto \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \

--- a/3.10/bullseye/slim/Dockerfile
+++ b/3.10/bullseye/slim/Dockerfile
@@ -71,6 +71,7 @@ RUN set -ex \
 		--enable-optimizations \
 		--enable-option-checking=fatal \
 		--enable-shared \
+		--with-lto \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \

--- a/3.10/buster/Dockerfile
+++ b/3.10/buster/Dockerfile
@@ -44,6 +44,7 @@ RUN set -ex \
 		--enable-optimizations \
 		--enable-option-checking=fatal \
 		--enable-shared \
+		--with-lto \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \

--- a/3.10/buster/slim/Dockerfile
+++ b/3.10/buster/slim/Dockerfile
@@ -71,6 +71,7 @@ RUN set -ex \
 		--enable-optimizations \
 		--enable-option-checking=fatal \
 		--enable-shared \
+		--with-lto \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \

--- a/3.11-rc/alpine3.14/Dockerfile
+++ b/3.11-rc/alpine3.14/Dockerfile
@@ -80,6 +80,7 @@ RUN set -ex \
 		--enable-optimizations \
 		--enable-option-checking=fatal \
 		--enable-shared \
+		--with-lto \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \

--- a/3.11-rc/bullseye/Dockerfile
+++ b/3.11-rc/bullseye/Dockerfile
@@ -44,6 +44,7 @@ RUN set -ex \
 		--enable-optimizations \
 		--enable-option-checking=fatal \
 		--enable-shared \
+		--with-lto \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \

--- a/3.11-rc/bullseye/slim/Dockerfile
+++ b/3.11-rc/bullseye/slim/Dockerfile
@@ -71,6 +71,7 @@ RUN set -ex \
 		--enable-optimizations \
 		--enable-option-checking=fatal \
 		--enable-shared \
+		--with-lto \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -74,6 +74,7 @@ RUN set -ex \
 		--enable-optimizations \
 		--enable-option-checking=fatal \
 		--enable-shared \
+		--with-lto \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -38,6 +38,7 @@ RUN set -ex \
 		--enable-optimizations \
 		--enable-option-checking=fatal \
 		--enable-shared \
+		--with-lto \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -65,6 +65,7 @@ RUN set -ex \
 		--enable-optimizations \
 		--enable-option-checking=fatal \
 		--enable-shared \
+		--with-lto \
 		--with-system-expat \
 		--with-system-ffi \
 		--without-ensurepip \

--- a/update.sh
+++ b/update.sh
@@ -253,5 +253,10 @@ for version in "${versions[@]}"; do
 		if [ "$minor" -lt 9 ]; then
 			sed -ri -e '/tzdata/d' "$dir/Dockerfile"
 		fi
+
+		if [ "$minor" -lt 10 ]; then
+			# <3.10 does not have -fno-semantic-interposition enabled and --with-lto does nothing for performance
+			sed -ri -e '/with-lto/d' "$dir/Dockerfile"
+		fi
 	done
 done


### PR DESCRIPTION
This PR is to add `--with-lto` to Python images 3.10 and newer as those Pythons are now configured with `-fno-semantic-interposition` upstream. This is a performance enhancement. 