### PR TITLE
Don't strip debugging symbols in the regular Debian images

### DIFF
--- a/3.10/bullseye/Dockerfile
+++ b/3.10/bullseye/Dockerfile
@@ -54,7 +54,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	cd /; \

--- a/3.10/buster/Dockerfile
+++ b/3.10/buster/Dockerfile
@@ -54,7 +54,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	cd /; \

--- a/3.11-rc/bullseye/Dockerfile
+++ b/3.11-rc/bullseye/Dockerfile
@@ -54,7 +54,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	cd /; \

--- a/3.11-rc/buster/Dockerfile
+++ b/3.11-rc/buster/Dockerfile
@@ -54,7 +54,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	cd /; \

--- a/3.7/bullseye/Dockerfile
+++ b/3.7/bullseye/Dockerfile
@@ -53,7 +53,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
 # setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
 		PROFILE_TASK='-m test.regrtest --pgo \
 			test_array \

--- a/3.7/buster/Dockerfile
+++ b/3.7/buster/Dockerfile
@@ -53,7 +53,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
 # setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
 		PROFILE_TASK='-m test.regrtest --pgo \
 			test_array \

--- a/3.8/bullseye/Dockerfile
+++ b/3.8/bullseye/Dockerfile
@@ -53,7 +53,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	cd /; \

--- a/3.8/buster/Dockerfile
+++ b/3.8/buster/Dockerfile
@@ -53,7 +53,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	cd /; \

--- a/3.9/bullseye/Dockerfile
+++ b/3.9/bullseye/Dockerfile
@@ -53,7 +53,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	cd /; \

--- a/3.9/buster/Dockerfile
+++ b/3.9/buster/Dockerfile
@@ -53,7 +53,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	cd /; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -170,7 +170,9 @@ RUN set -eux; \
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
 {{ ) else "" end -}}
+{{ if is_slim or is_alpine then ( -}}
 		LDFLAGS="-Wl,--strip-all" \
+{{ ) else "" end -}}
 {{ if env.version == "3.7" then ( -}}
 # setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
 		PROFILE_TASK='-m test.regrtest --pgo \


### PR DESCRIPTION
Since #687, the regular Debian images no longer ship DWARF symbols, which heavily limits the ability to use gdb and lldb for debugging.

Stripping debugging symbols makes perfect sense to reduce the size of Docker images, but when this optimization was first introduced in #483, the idea was to restrict its use to the slim and Alpine images. That was (unintentionally?) changed in #483, and now debugging symbols are also stripped in the regular Debian images. Undo that change.

Fixes #694 .