### PR TITLE
Remove coreutils package from Alpine build dependencies

### DIFF
--- a/3.10/alpine3.14/Dockerfile
+++ b/3.10/alpine3.14/Dockerfile
@@ -32,7 +32,6 @@ RUN set -eux; \
 		\
 		bluez-dev \
 		bzip2-dev \
-		coreutils \
 		dpkg-dev dpkg \
 		expat-dev \
 		findutils \

--- a/3.10/alpine3.15/Dockerfile
+++ b/3.10/alpine3.15/Dockerfile
@@ -32,7 +32,6 @@ RUN set -eux; \
 		\
 		bluez-dev \
 		bzip2-dev \
-		coreutils \
 		dpkg-dev dpkg \
 		expat-dev \
 		findutils \

--- a/3.11-rc/alpine3.14/Dockerfile
+++ b/3.11-rc/alpine3.14/Dockerfile
@@ -32,7 +32,6 @@ RUN set -eux; \
 		\
 		bluez-dev \
 		bzip2-dev \
-		coreutils \
 		dpkg-dev dpkg \
 		expat-dev \
 		findutils \

--- a/3.11-rc/alpine3.15/Dockerfile
+++ b/3.11-rc/alpine3.15/Dockerfile
@@ -32,7 +32,6 @@ RUN set -eux; \
 		\
 		bluez-dev \
 		bzip2-dev \
-		coreutils \
 		dpkg-dev dpkg \
 		expat-dev \
 		findutils \

--- a/3.7/alpine3.14/Dockerfile
+++ b/3.7/alpine3.14/Dockerfile
@@ -32,7 +32,6 @@ RUN set -eux; \
 		\
 		bluez-dev \
 		bzip2-dev \
-		coreutils \
 		dpkg-dev dpkg \
 		expat-dev \
 		findutils \

--- a/3.7/alpine3.15/Dockerfile
+++ b/3.7/alpine3.15/Dockerfile
@@ -32,7 +32,6 @@ RUN set -eux; \
 		\
 		bluez-dev \
 		bzip2-dev \
-		coreutils \
 		dpkg-dev dpkg \
 		expat-dev \
 		findutils \

--- a/3.8/alpine3.14/Dockerfile
+++ b/3.8/alpine3.14/Dockerfile
@@ -32,7 +32,6 @@ RUN set -eux; \
 		\
 		bluez-dev \
 		bzip2-dev \
-		coreutils \
 		dpkg-dev dpkg \
 		expat-dev \
 		findutils \

--- a/3.8/alpine3.15/Dockerfile
+++ b/3.8/alpine3.15/Dockerfile
@@ -32,7 +32,6 @@ RUN set -eux; \
 		\
 		bluez-dev \
 		bzip2-dev \
-		coreutils \
 		dpkg-dev dpkg \
 		expat-dev \
 		findutils \

--- a/3.9/alpine3.14/Dockerfile
+++ b/3.9/alpine3.14/Dockerfile
@@ -32,7 +32,6 @@ RUN set -eux; \
 		\
 		bluez-dev \
 		bzip2-dev \
-		coreutils \
 		dpkg-dev dpkg \
 		expat-dev \
 		findutils \

--- a/3.9/alpine3.15/Dockerfile
+++ b/3.9/alpine3.15/Dockerfile
@@ -32,7 +32,6 @@ RUN set -eux; \
 		\
 		bluez-dev \
 		bzip2-dev \
-		coreutils \
 		dpkg-dev dpkg \
 		expat-dev \
 		findutils \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -82,7 +82,6 @@ RUN set -eux; \
 		\
 		bluez-dev \
 		bzip2-dev \
-		coreutils \
 		dpkg-dev dpkg \
 		expat-dev \
 		findutils \


### PR DESCRIPTION
Because I think that it's not needed.

Refs https://github.com/hassio-addons/addon-base-python/issues/102
Refs https://github.com/hassio-addons/addon-base-python/pull/103