### PR TITLE
Prevent removing unexpected .a files in case of re-using the Dockerfile to build custom image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,23 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/docker-library/bashbrew.git -b master ~/bashbrew
           strategy="$(~/bashbrew/scripts/github-actions/generate.sh)"
+
+          # https://github.com/docker-library/python/pull/706 (ensure we don't have any unexpected ".a" leftovers in "/usr/local")
+          strategy="$(jq <<<"$strategy" -c '
+            .matrix.include |= map(
+              if .os == "ubuntu-latest" then
+                .runs.test += "\n" + (
+                  .meta.entries
+                  | map(
+                    .tags[0]
+                    | "aFiles=\"$(docker run --rm \(. | @sh) find /usr/local -name \"*.a\" | tee /dev/stderr)\"; [ -z \"$aFiles\" ]"
+                  )
+                  | join("\n")
+                )
+              else . end
+            )
+          ')"
+
           jq . <<<"$strategy" # sanity check / debugging aid
           echo "::set-output name=strategy::$strategy"
 

--- a/3.10/alpine3.14/Dockerfile
+++ b/3.10/alpine3.14/Dockerfile
@@ -95,7 +95,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\

--- a/3.10/alpine3.15/Dockerfile
+++ b/3.10/alpine3.15/Dockerfile
@@ -95,7 +95,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\

--- a/3.10/bullseye/Dockerfile
+++ b/3.10/bullseye/Dockerfile
@@ -69,7 +69,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\

--- a/3.10/buster/Dockerfile
+++ b/3.10/buster/Dockerfile
@@ -69,7 +69,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\

--- a/3.10/slim-bullseye/Dockerfile
+++ b/3.10/slim-bullseye/Dockerfile
@@ -89,7 +89,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\

--- a/3.10/slim-buster/Dockerfile
+++ b/3.10/slim-buster/Dockerfile
@@ -89,7 +89,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\

--- a/3.11-rc/alpine3.14/Dockerfile
+++ b/3.11-rc/alpine3.14/Dockerfile
@@ -95,7 +95,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\

--- a/3.11-rc/alpine3.15/Dockerfile
+++ b/3.11-rc/alpine3.15/Dockerfile
@@ -95,7 +95,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\

--- a/3.11-rc/bullseye/Dockerfile
+++ b/3.11-rc/bullseye/Dockerfile
@@ -69,7 +69,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\

--- a/3.11-rc/buster/Dockerfile
+++ b/3.11-rc/buster/Dockerfile
@@ -69,7 +69,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\

--- a/3.11-rc/slim-bullseye/Dockerfile
+++ b/3.11-rc/slim-bullseye/Dockerfile
@@ -89,7 +89,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\

--- a/3.11-rc/slim-buster/Dockerfile
+++ b/3.11-rc/slim-buster/Dockerfile
@@ -89,7 +89,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\

--- a/3.7/alpine3.14/Dockerfile
+++ b/3.7/alpine3.14/Dockerfile
@@ -130,7 +130,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 			-o \( -type f -a -name 'wininst-*.exe' \) \
 		\) -exec rm -rf '{}' + \
 	; \

--- a/3.7/alpine3.15/Dockerfile
+++ b/3.7/alpine3.15/Dockerfile
@@ -130,7 +130,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 			-o \( -type f -a -name 'wininst-*.exe' \) \
 		\) -exec rm -rf '{}' + \
 	; \

--- a/3.7/bullseye/Dockerfile
+++ b/3.7/bullseye/Dockerfile
@@ -104,7 +104,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 			-o \( -type f -a -name 'wininst-*.exe' \) \
 		\) -exec rm -rf '{}' + \
 	; \

--- a/3.7/buster/Dockerfile
+++ b/3.7/buster/Dockerfile
@@ -104,7 +104,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 			-o \( -type f -a -name 'wininst-*.exe' \) \
 		\) -exec rm -rf '{}' + \
 	; \

--- a/3.7/slim-bullseye/Dockerfile
+++ b/3.7/slim-bullseye/Dockerfile
@@ -124,7 +124,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 			-o \( -type f -a -name 'wininst-*.exe' \) \
 		\) -exec rm -rf '{}' + \
 	; \

--- a/3.7/slim-buster/Dockerfile
+++ b/3.7/slim-buster/Dockerfile
@@ -124,7 +124,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 			-o \( -type f -a -name 'wininst-*.exe' \) \
 		\) -exec rm -rf '{}' + \
 	; \

--- a/3.8/alpine3.14/Dockerfile
+++ b/3.8/alpine3.14/Dockerfile
@@ -94,7 +94,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 			-o \( -type f -a -name 'wininst-*.exe' \) \
 		\) -exec rm -rf '{}' + \
 	; \

--- a/3.8/alpine3.15/Dockerfile
+++ b/3.8/alpine3.15/Dockerfile
@@ -94,7 +94,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 			-o \( -type f -a -name 'wininst-*.exe' \) \
 		\) -exec rm -rf '{}' + \
 	; \

--- a/3.8/bullseye/Dockerfile
+++ b/3.8/bullseye/Dockerfile
@@ -68,7 +68,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 			-o \( -type f -a -name 'wininst-*.exe' \) \
 		\) -exec rm -rf '{}' + \
 	; \

--- a/3.8/buster/Dockerfile
+++ b/3.8/buster/Dockerfile
@@ -68,7 +68,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 			-o \( -type f -a -name 'wininst-*.exe' \) \
 		\) -exec rm -rf '{}' + \
 	; \

--- a/3.8/slim-bullseye/Dockerfile
+++ b/3.8/slim-bullseye/Dockerfile
@@ -88,7 +88,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 			-o \( -type f -a -name 'wininst-*.exe' \) \
 		\) -exec rm -rf '{}' + \
 	; \

--- a/3.8/slim-buster/Dockerfile
+++ b/3.8/slim-buster/Dockerfile
@@ -88,7 +88,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 			-o \( -type f -a -name 'wininst-*.exe' \) \
 		\) -exec rm -rf '{}' + \
 	; \

--- a/3.9/alpine3.14/Dockerfile
+++ b/3.9/alpine3.14/Dockerfile
@@ -94,7 +94,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\

--- a/3.9/alpine3.15/Dockerfile
+++ b/3.9/alpine3.15/Dockerfile
@@ -94,7 +94,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\

--- a/3.9/bullseye/Dockerfile
+++ b/3.9/bullseye/Dockerfile
@@ -68,7 +68,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\

--- a/3.9/buster/Dockerfile
+++ b/3.9/buster/Dockerfile
@@ -68,7 +68,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\

--- a/3.9/slim-bullseye/Dockerfile
+++ b/3.9/slim-bullseye/Dockerfile
@@ -88,7 +88,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\

--- a/3.9/slim-buster/Dockerfile
+++ b/3.9/slim-buster/Dockerfile
@@ -88,7 +88,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -235,7 +235,7 @@ RUN set -eux; \
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
 {{ if [ "3.7", "3.8" ] | index(env.version) then ( -}}
 			-o \( -type f -a -name 'wininst-*.exe' \) \
 {{


### PR DESCRIPTION
Hello, I'd like to propose a slight change for cleaning up `*.a` which is defined here, so that it doesn't delete unexpected files.
https://github.com/docker-library/python/blob/0047f00c0967161e731c9bab7d50fd95c7c09d46/3.10/slim-buster/Dockerfile#L92

Here is my background:
The current Dockerfile for the dockerhub Python image itself works pretty fine; it doesn't remove anything unexpected, even without my proposal.
However, since this official Dockerfile is so useful, clean and general, we often re-use (borrow) its content to make our own images on top of another image, typically by just rewriting the `FROM` section to something other.
For example, which is my actual case, we build a Python-ready image on top of `nvidia/cuda:11.6.0-xxx`. The issue here is that removing all the `*.a` under `/usr/local` as written in the current Dockerfile also destroys CUDA libraries. This combination is just an example but I think the same thing can happen in other patterns.

Looking at the actual files cleaned up here while building Python 3.10 images for `slim-buster` and `alpine3.15`, I found out `/usr/local/lib/python3.10/config-3.10-x86_64-linux-gnu/libpython3.10.a` is the only `*.a` file removed. So I think modifying the rule for the `find` command from `'*.a'` to `'libpython*.a'` can prevent unexpectedly removing .a files of other libraries in case modifying `FROM` section, while it doesn't change anything on the image for dockerhub.