### PR TITLE
Restore /usr/local/bin/python as a relative symlink to /usr/local/bin/python3

### DIFF
--- a/3.10/alpine3.14/Dockerfile
+++ b/3.10/alpine3.14/Dockerfile
@@ -115,7 +115,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.10/alpine3.15/Dockerfile
+++ b/3.10/alpine3.15/Dockerfile
@@ -115,7 +115,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.10/bullseye/Dockerfile
+++ b/3.10/bullseye/Dockerfile
@@ -83,7 +83,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.10/buster/Dockerfile
+++ b/3.10/buster/Dockerfile
@@ -83,7 +83,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.10/slim-bullseye/Dockerfile
+++ b/3.10/slim-bullseye/Dockerfile
@@ -116,7 +116,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.10/slim-buster/Dockerfile
+++ b/3.10/slim-buster/Dockerfile
@@ -116,7 +116,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.11-rc/alpine3.14/Dockerfile
+++ b/3.11-rc/alpine3.14/Dockerfile
@@ -115,7 +115,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.11-rc/alpine3.15/Dockerfile
+++ b/3.11-rc/alpine3.15/Dockerfile
@@ -115,7 +115,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.11-rc/bullseye/Dockerfile
+++ b/3.11-rc/bullseye/Dockerfile
@@ -83,7 +83,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.11-rc/buster/Dockerfile
+++ b/3.11-rc/buster/Dockerfile
@@ -83,7 +83,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.11-rc/slim-bullseye/Dockerfile
+++ b/3.11-rc/slim-bullseye/Dockerfile
@@ -116,7 +116,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.11-rc/slim-buster/Dockerfile
+++ b/3.11-rc/slim-buster/Dockerfile
@@ -116,7 +116,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.7/alpine3.14/Dockerfile
+++ b/3.7/alpine3.14/Dockerfile
@@ -151,7 +151,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.7/alpine3.15/Dockerfile
+++ b/3.7/alpine3.15/Dockerfile
@@ -151,7 +151,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.7/bullseye/Dockerfile
+++ b/3.7/bullseye/Dockerfile
@@ -119,7 +119,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.7/buster/Dockerfile
+++ b/3.7/buster/Dockerfile
@@ -119,7 +119,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.7/slim-bullseye/Dockerfile
+++ b/3.7/slim-bullseye/Dockerfile
@@ -152,7 +152,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.7/slim-buster/Dockerfile
+++ b/3.7/slim-buster/Dockerfile
@@ -152,7 +152,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.8/alpine3.14/Dockerfile
+++ b/3.8/alpine3.14/Dockerfile
@@ -115,7 +115,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.8/alpine3.15/Dockerfile
+++ b/3.8/alpine3.15/Dockerfile
@@ -115,7 +115,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.8/bullseye/Dockerfile
+++ b/3.8/bullseye/Dockerfile
@@ -83,7 +83,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.8/buster/Dockerfile
+++ b/3.8/buster/Dockerfile
@@ -83,7 +83,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.8/slim-bullseye/Dockerfile
+++ b/3.8/slim-bullseye/Dockerfile
@@ -116,7 +116,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.8/slim-buster/Dockerfile
+++ b/3.8/slim-buster/Dockerfile
@@ -116,7 +116,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.9/alpine3.14/Dockerfile
+++ b/3.9/alpine3.14/Dockerfile
@@ -114,7 +114,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.9/alpine3.15/Dockerfile
+++ b/3.9/alpine3.15/Dockerfile
@@ -114,7 +114,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.9/bullseye/Dockerfile
+++ b/3.9/bullseye/Dockerfile
@@ -82,7 +82,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.9/buster/Dockerfile
+++ b/3.9/buster/Dockerfile
@@ -82,7 +82,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.9/slim-bullseye/Dockerfile
+++ b/3.9/slim-bullseye/Dockerfile
@@ -115,7 +115,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3.9/slim-buster/Dockerfile
+++ b/3.9/slim-buster/Dockerfile
@@ -115,7 +115,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -282,7 +282,7 @@ RUN set -eux; \
 		dst="$(echo "$src" | tr -d 3)"; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "/usr/local/bin/$src" "/usr/local/bin/$dst"; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"


### PR DESCRIPTION
Follows-up on https://github.com/docker-library/python/pull/687#discussion_r797810032 (cc @tianon).