### PR TITLE
Remove redundant `--with-system-ffi` configure option

### DIFF
--- a/3.10/alpine3.14/Dockerfile
+++ b/3.10/alpine3.14/Dockerfile
@@ -77,7 +77,6 @@ RUN set -eux; \
 		--enable-shared \
 		--with-lto \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.10/alpine3.15/Dockerfile
+++ b/3.10/alpine3.15/Dockerfile
@@ -77,7 +77,6 @@ RUN set -eux; \
 		--enable-shared \
 		--with-lto \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.10/bullseye/Dockerfile
+++ b/3.10/bullseye/Dockerfile
@@ -49,7 +49,6 @@ RUN set -eux; \
 		--enable-shared \
 		--with-lto \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.10/buster/Dockerfile
+++ b/3.10/buster/Dockerfile
@@ -49,7 +49,6 @@ RUN set -eux; \
 		--enable-shared \
 		--with-lto \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.10/slim-bullseye/Dockerfile
+++ b/3.10/slim-bullseye/Dockerfile
@@ -74,7 +74,6 @@ RUN set -eux; \
 		--enable-shared \
 		--with-lto \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.10/slim-buster/Dockerfile
+++ b/3.10/slim-buster/Dockerfile
@@ -74,7 +74,6 @@ RUN set -eux; \
 		--enable-shared \
 		--with-lto \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.11-rc/alpine3.14/Dockerfile
+++ b/3.11-rc/alpine3.14/Dockerfile
@@ -77,7 +77,6 @@ RUN set -eux; \
 		--enable-shared \
 		--with-lto \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.11-rc/alpine3.15/Dockerfile
+++ b/3.11-rc/alpine3.15/Dockerfile
@@ -77,7 +77,6 @@ RUN set -eux; \
 		--enable-shared \
 		--with-lto \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.11-rc/bullseye/Dockerfile
+++ b/3.11-rc/bullseye/Dockerfile
@@ -49,7 +49,6 @@ RUN set -eux; \
 		--enable-shared \
 		--with-lto \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.11-rc/buster/Dockerfile
+++ b/3.11-rc/buster/Dockerfile
@@ -49,7 +49,6 @@ RUN set -eux; \
 		--enable-shared \
 		--with-lto \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.11-rc/slim-bullseye/Dockerfile
+++ b/3.11-rc/slim-bullseye/Dockerfile
@@ -74,7 +74,6 @@ RUN set -eux; \
 		--enable-shared \
 		--with-lto \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.11-rc/slim-buster/Dockerfile
+++ b/3.11-rc/slim-buster/Dockerfile
@@ -74,7 +74,6 @@ RUN set -eux; \
 		--enable-shared \
 		--with-lto \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.7/alpine3.14/Dockerfile
+++ b/3.7/alpine3.14/Dockerfile
@@ -76,7 +76,6 @@ RUN set -eux; \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.7/alpine3.15/Dockerfile
+++ b/3.7/alpine3.15/Dockerfile
@@ -76,7 +76,6 @@ RUN set -eux; \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.7/bullseye/Dockerfile
+++ b/3.7/bullseye/Dockerfile
@@ -48,7 +48,6 @@ RUN set -eux; \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.7/buster/Dockerfile
+++ b/3.7/buster/Dockerfile
@@ -48,7 +48,6 @@ RUN set -eux; \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.7/slim-bullseye/Dockerfile
+++ b/3.7/slim-bullseye/Dockerfile
@@ -73,7 +73,6 @@ RUN set -eux; \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.7/slim-buster/Dockerfile
+++ b/3.7/slim-buster/Dockerfile
@@ -73,7 +73,6 @@ RUN set -eux; \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.8/alpine3.14/Dockerfile
+++ b/3.8/alpine3.14/Dockerfile
@@ -76,7 +76,6 @@ RUN set -eux; \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.8/alpine3.15/Dockerfile
+++ b/3.8/alpine3.15/Dockerfile
@@ -76,7 +76,6 @@ RUN set -eux; \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.8/bullseye/Dockerfile
+++ b/3.8/bullseye/Dockerfile
@@ -48,7 +48,6 @@ RUN set -eux; \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.8/buster/Dockerfile
+++ b/3.8/buster/Dockerfile
@@ -48,7 +48,6 @@ RUN set -eux; \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.8/slim-bullseye/Dockerfile
+++ b/3.8/slim-bullseye/Dockerfile
@@ -73,7 +73,6 @@ RUN set -eux; \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.8/slim-buster/Dockerfile
+++ b/3.8/slim-buster/Dockerfile
@@ -73,7 +73,6 @@ RUN set -eux; \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.9/alpine3.14/Dockerfile
+++ b/3.9/alpine3.14/Dockerfile
@@ -76,7 +76,6 @@ RUN set -eux; \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.9/alpine3.15/Dockerfile
+++ b/3.9/alpine3.15/Dockerfile
@@ -76,7 +76,6 @@ RUN set -eux; \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.9/bullseye/Dockerfile
+++ b/3.9/bullseye/Dockerfile
@@ -48,7 +48,6 @@ RUN set -eux; \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.9/buster/Dockerfile
+++ b/3.9/buster/Dockerfile
@@ -48,7 +48,6 @@ RUN set -eux; \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.9/slim-bullseye/Dockerfile
+++ b/3.9/slim-bullseye/Dockerfile
@@ -73,7 +73,6 @@ RUN set -eux; \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/3.9/slim-buster/Dockerfile
+++ b/3.9/slim-buster/Dockerfile
@@ -73,7 +73,6 @@ RUN set -eux; \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -159,7 +159,6 @@ RUN set -eux; \
 		--with-lto \
 {{ ) end -}}
 		--with-system-expat \
-		--with-system-ffi \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \


### PR DESCRIPTION
Since as of Python 3.7+ using system `ffi` is now mandatory (and so the default) on Linux:
https://bugs.python.org/issue27979
https://github.com/python/cpython/commit/f40d4ddff3c800b3c956a5e8820aabe3aa87cddd

Removing the option resolves this configure warning:

```
checking for --with-system-ffi... yes
configure: WARNING: --with(out)-system-ffi is ignored on this platform
```

Closes #715.