### PR TITLE
Revert "Remove mips64le from 3.10"

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -144,11 +144,6 @@ for version; do
 			sharedTags+=( "${versionAliases[@]}" )
 		fi
 
-		if [ "$version" = '3.10' ]; then
-			# https://github.com/docker-library/python/issues/682
-			variantArches="$(sed -r -e 's/ mips64le / /g' <<<" $variantArches ")"
-		fi
-
 		echo
 		echo "Tags: $(join ', ' "${variantAliases[@]}")"
 		if [ "${#sharedTags[@]}" -gt 0 ]; then


### PR DESCRIPTION
Reverts docker-library/python#683

Closes https://github.com/docker-library/python/issues/682 (now fixed! :+1:)