### PR TITLE
Better rpath fix

### DIFF
--- a/3.10/alpine3.16/Dockerfile
+++ b/3.10/alpine3.16/Dockerfile
@@ -45,6 +45,7 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
+		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -87,6 +88,11 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.10/alpine3.16/Dockerfile
+++ b/3.10/alpine3.16/Dockerfile
@@ -84,10 +84,7 @@ RUN set -eux; \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	\

--- a/3.10/alpine3.17/Dockerfile
+++ b/3.10/alpine3.17/Dockerfile
@@ -45,6 +45,7 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
+		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -87,6 +88,11 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.10/alpine3.17/Dockerfile
+++ b/3.10/alpine3.17/Dockerfile
@@ -84,10 +84,7 @@ RUN set -eux; \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	\

--- a/3.10/bullseye/Dockerfile
+++ b/3.10/bullseye/Dockerfile
@@ -28,6 +28,12 @@ ENV PYTHON_VERSION 3.10.9
 
 RUN set -eux; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		patchelf \
+	; \
+	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -56,8 +62,12 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
+	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
-	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -73,6 +83,11 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.10/bullseye/Dockerfile
+++ b/3.10/bullseye/Dockerfile
@@ -53,10 +53,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
 	; \
 	make install; \
 	\

--- a/3.10/buster/Dockerfile
+++ b/3.10/buster/Dockerfile
@@ -28,6 +28,12 @@ ENV PYTHON_VERSION 3.10.9
 
 RUN set -eux; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		patchelf \
+	; \
+	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -56,8 +62,12 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
+	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
-	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -73,6 +83,11 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.10/buster/Dockerfile
+++ b/3.10/buster/Dockerfile
@@ -53,10 +53,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
 	; \
 	make install; \
 	\

--- a/3.10/slim-bullseye/Dockerfile
+++ b/3.10/slim-bullseye/Dockerfile
@@ -46,6 +46,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -81,6 +82,11 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.10/slim-bullseye/Dockerfile
+++ b/3.10/slim-bullseye/Dockerfile
@@ -78,10 +78,7 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	\

--- a/3.10/slim-buster/Dockerfile
+++ b/3.10/slim-buster/Dockerfile
@@ -46,6 +46,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -81,6 +82,11 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.10/slim-buster/Dockerfile
+++ b/3.10/slim-buster/Dockerfile
@@ -78,10 +78,7 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	\

--- a/3.11/alpine3.16/Dockerfile
+++ b/3.11/alpine3.16/Dockerfile
@@ -45,6 +45,7 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
+		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -87,6 +88,11 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.11/alpine3.16/Dockerfile
+++ b/3.11/alpine3.16/Dockerfile
@@ -84,10 +84,7 @@ RUN set -eux; \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	\

--- a/3.11/alpine3.17/Dockerfile
+++ b/3.11/alpine3.17/Dockerfile
@@ -45,6 +45,7 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
+		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -87,6 +88,11 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.11/alpine3.17/Dockerfile
+++ b/3.11/alpine3.17/Dockerfile
@@ -84,10 +84,7 @@ RUN set -eux; \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	\

--- a/3.11/bullseye/Dockerfile
+++ b/3.11/bullseye/Dockerfile
@@ -28,6 +28,12 @@ ENV PYTHON_VERSION 3.11.1
 
 RUN set -eux; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		patchelf \
+	; \
+	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -56,8 +62,12 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
+	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
-	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -73,6 +83,11 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.11/bullseye/Dockerfile
+++ b/3.11/bullseye/Dockerfile
@@ -53,10 +53,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
 	; \
 	make install; \
 	\

--- a/3.11/buster/Dockerfile
+++ b/3.11/buster/Dockerfile
@@ -28,6 +28,12 @@ ENV PYTHON_VERSION 3.11.1
 
 RUN set -eux; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		patchelf \
+	; \
+	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -56,8 +62,12 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
+	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
-	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -73,6 +83,11 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.11/buster/Dockerfile
+++ b/3.11/buster/Dockerfile
@@ -53,10 +53,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
 	; \
 	make install; \
 	\

--- a/3.11/slim-bullseye/Dockerfile
+++ b/3.11/slim-bullseye/Dockerfile
@@ -46,6 +46,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -81,6 +82,11 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.11/slim-bullseye/Dockerfile
+++ b/3.11/slim-bullseye/Dockerfile
@@ -78,10 +78,7 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	\

--- a/3.11/slim-buster/Dockerfile
+++ b/3.11/slim-buster/Dockerfile
@@ -46,6 +46,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -81,6 +82,11 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.11/slim-buster/Dockerfile
+++ b/3.11/slim-buster/Dockerfile
@@ -78,10 +78,7 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	\

--- a/3.12-rc/alpine3.16/Dockerfile
+++ b/3.12-rc/alpine3.16/Dockerfile
@@ -45,6 +45,7 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
+		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -87,6 +88,11 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.12-rc/alpine3.16/Dockerfile
+++ b/3.12-rc/alpine3.16/Dockerfile
@@ -84,10 +84,7 @@ RUN set -eux; \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	\

--- a/3.12-rc/alpine3.17/Dockerfile
+++ b/3.12-rc/alpine3.17/Dockerfile
@@ -45,6 +45,7 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
+		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -87,6 +88,11 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.12-rc/alpine3.17/Dockerfile
+++ b/3.12-rc/alpine3.17/Dockerfile
@@ -84,10 +84,7 @@ RUN set -eux; \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	\

--- a/3.12-rc/bullseye/Dockerfile
+++ b/3.12-rc/bullseye/Dockerfile
@@ -53,10 +53,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
 	; \
 	make install; \
 	\

--- a/3.12-rc/bullseye/Dockerfile
+++ b/3.12-rc/bullseye/Dockerfile
@@ -28,6 +28,12 @@ ENV PYTHON_VERSION 3.12.0a4
 
 RUN set -eux; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		patchelf \
+	; \
+	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -56,8 +62,12 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
+	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
-	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -73,6 +83,11 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.12-rc/buster/Dockerfile
+++ b/3.12-rc/buster/Dockerfile
@@ -53,10 +53,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
 	; \
 	make install; \
 	\

--- a/3.12-rc/buster/Dockerfile
+++ b/3.12-rc/buster/Dockerfile
@@ -28,6 +28,12 @@ ENV PYTHON_VERSION 3.12.0a4
 
 RUN set -eux; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		patchelf \
+	; \
+	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -56,8 +62,12 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
+	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
-	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -73,6 +83,11 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.12-rc/slim-bullseye/Dockerfile
+++ b/3.12-rc/slim-bullseye/Dockerfile
@@ -46,6 +46,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -81,6 +82,11 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.12-rc/slim-bullseye/Dockerfile
+++ b/3.12-rc/slim-bullseye/Dockerfile
@@ -78,10 +78,7 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	\

--- a/3.12-rc/slim-buster/Dockerfile
+++ b/3.12-rc/slim-buster/Dockerfile
@@ -46,6 +46,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -81,6 +82,11 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.12-rc/slim-buster/Dockerfile
+++ b/3.12-rc/slim-buster/Dockerfile
@@ -78,10 +78,7 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	\

--- a/3.7/alpine3.16/Dockerfile
+++ b/3.7/alpine3.16/Dockerfile
@@ -45,6 +45,7 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
+		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -122,6 +123,11 @@ RUN set -eux; \
 		' \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.7/alpine3.16/Dockerfile
+++ b/3.7/alpine3.16/Dockerfile
@@ -83,10 +83,7 @@ RUN set -eux; \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 # setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
 		PROFILE_TASK='-m test.regrtest --pgo \
 			test_array \

--- a/3.7/alpine3.17/Dockerfile
+++ b/3.7/alpine3.17/Dockerfile
@@ -45,6 +45,7 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
+		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -122,6 +123,11 @@ RUN set -eux; \
 		' \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.7/alpine3.17/Dockerfile
+++ b/3.7/alpine3.17/Dockerfile
@@ -83,10 +83,7 @@ RUN set -eux; \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 # setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
 		PROFILE_TASK='-m test.regrtest --pgo \
 			test_array \

--- a/3.7/bullseye/Dockerfile
+++ b/3.7/bullseye/Dockerfile
@@ -28,6 +28,12 @@ ENV PYTHON_VERSION 3.7.16
 
 RUN set -eux; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		patchelf \
+	; \
+	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -91,8 +97,12 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
+	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
-	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -109,6 +119,11 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.7/bullseye/Dockerfile
+++ b/3.7/bullseye/Dockerfile
@@ -52,10 +52,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
 # setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
 		PROFILE_TASK='-m test.regrtest --pgo \
 			test_array \

--- a/3.7/buster/Dockerfile
+++ b/3.7/buster/Dockerfile
@@ -28,6 +28,12 @@ ENV PYTHON_VERSION 3.7.16
 
 RUN set -eux; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		patchelf \
+	; \
+	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -91,8 +97,12 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
+	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
-	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -109,6 +119,11 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.7/buster/Dockerfile
+++ b/3.7/buster/Dockerfile
@@ -52,10 +52,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
 # setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
 		PROFILE_TASK='-m test.regrtest --pgo \
 			test_array \

--- a/3.7/slim-bullseye/Dockerfile
+++ b/3.7/slim-bullseye/Dockerfile
@@ -77,10 +77,7 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 # setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
 		PROFILE_TASK='-m test.regrtest --pgo \
 			test_array \

--- a/3.7/slim-bullseye/Dockerfile
+++ b/3.7/slim-bullseye/Dockerfile
@@ -46,6 +46,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -116,6 +117,11 @@ RUN set -eux; \
 		' \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.7/slim-buster/Dockerfile
+++ b/3.7/slim-buster/Dockerfile
@@ -77,10 +77,7 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 # setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
 		PROFILE_TASK='-m test.regrtest --pgo \
 			test_array \

--- a/3.7/slim-buster/Dockerfile
+++ b/3.7/slim-buster/Dockerfile
@@ -46,6 +46,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -116,6 +117,11 @@ RUN set -eux; \
 		' \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.8/alpine3.16/Dockerfile
+++ b/3.8/alpine3.16/Dockerfile
@@ -45,6 +45,7 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
+		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -86,6 +87,11 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.8/alpine3.16/Dockerfile
+++ b/3.8/alpine3.16/Dockerfile
@@ -83,10 +83,7 @@ RUN set -eux; \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	\

--- a/3.8/alpine3.17/Dockerfile
+++ b/3.8/alpine3.17/Dockerfile
@@ -45,6 +45,7 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
+		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -86,6 +87,11 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.8/alpine3.17/Dockerfile
+++ b/3.8/alpine3.17/Dockerfile
@@ -83,10 +83,7 @@ RUN set -eux; \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	\

--- a/3.8/bullseye/Dockerfile
+++ b/3.8/bullseye/Dockerfile
@@ -28,6 +28,12 @@ ENV PYTHON_VERSION 3.8.16
 
 RUN set -eux; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		patchelf \
+	; \
+	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -55,8 +61,12 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
+	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
-	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -73,6 +83,11 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.8/bullseye/Dockerfile
+++ b/3.8/bullseye/Dockerfile
@@ -52,10 +52,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
 	; \
 	make install; \
 	\

--- a/3.8/buster/Dockerfile
+++ b/3.8/buster/Dockerfile
@@ -28,6 +28,12 @@ ENV PYTHON_VERSION 3.8.16
 
 RUN set -eux; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		patchelf \
+	; \
+	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -55,8 +61,12 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
+	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
-	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -73,6 +83,11 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.8/buster/Dockerfile
+++ b/3.8/buster/Dockerfile
@@ -52,10 +52,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
 	; \
 	make install; \
 	\

--- a/3.8/slim-bullseye/Dockerfile
+++ b/3.8/slim-bullseye/Dockerfile
@@ -77,10 +77,7 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	\

--- a/3.8/slim-bullseye/Dockerfile
+++ b/3.8/slim-bullseye/Dockerfile
@@ -46,6 +46,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -80,6 +81,11 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.8/slim-buster/Dockerfile
+++ b/3.8/slim-buster/Dockerfile
@@ -77,10 +77,7 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	\

--- a/3.8/slim-buster/Dockerfile
+++ b/3.8/slim-buster/Dockerfile
@@ -46,6 +46,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -80,6 +81,11 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.9/alpine3.16/Dockerfile
+++ b/3.9/alpine3.16/Dockerfile
@@ -45,6 +45,7 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
+		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -86,6 +87,11 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.9/alpine3.16/Dockerfile
+++ b/3.9/alpine3.16/Dockerfile
@@ -83,10 +83,7 @@ RUN set -eux; \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	\

--- a/3.9/alpine3.17/Dockerfile
+++ b/3.9/alpine3.17/Dockerfile
@@ -45,6 +45,7 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
+		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -86,6 +87,11 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.9/alpine3.17/Dockerfile
+++ b/3.9/alpine3.17/Dockerfile
@@ -83,10 +83,7 @@ RUN set -eux; \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	\

--- a/3.9/bullseye/Dockerfile
+++ b/3.9/bullseye/Dockerfile
@@ -28,6 +28,12 @@ ENV PYTHON_VERSION 3.9.16
 
 RUN set -eux; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		patchelf \
+	; \
+	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -55,8 +61,12 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
+	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
-	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -72,6 +82,11 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.9/bullseye/Dockerfile
+++ b/3.9/bullseye/Dockerfile
@@ -52,10 +52,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
 	; \
 	make install; \
 	\

--- a/3.9/buster/Dockerfile
+++ b/3.9/buster/Dockerfile
@@ -28,6 +28,12 @@ ENV PYTHON_VERSION 3.9.16
 
 RUN set -eux; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		patchelf \
+	; \
+	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -55,8 +61,12 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
+	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
-	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -72,6 +82,11 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.9/buster/Dockerfile
+++ b/3.9/buster/Dockerfile
@@ -52,10 +52,6 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
 	; \
 	make install; \
 	\

--- a/3.9/slim-bullseye/Dockerfile
+++ b/3.9/slim-bullseye/Dockerfile
@@ -77,10 +77,7 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	\

--- a/3.9/slim-bullseye/Dockerfile
+++ b/3.9/slim-bullseye/Dockerfile
@@ -46,6 +46,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -80,6 +81,11 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.9/slim-buster/Dockerfile
+++ b/3.9/slim-buster/Dockerfile
@@ -77,10 +77,7 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
 	\

--- a/3.9/slim-buster/Dockerfile
+++ b/3.9/slim-buster/Dockerfile
@@ -46,6 +46,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -80,6 +81,11 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -99,6 +99,7 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
+		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -110,10 +111,11 @@ RUN set -eux; \
 		zlib-dev \
 	; \
 	\
-{{ ) elif is_slim then ( -}}
+{{ ) else ( -}}
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+{{ if is_slim then ( -}}
 		dpkg-dev \
 		gcc \
 		gnupg dirmngr \
@@ -129,14 +131,18 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
+		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
 		xz-utils \
 		zlib1g-dev \
+{{ ) else ( -}}
+		patchelf \
+{{ ) end -}}
 	; \
 	\
-{{ ) else "" end -}}
+{{ ) end -}}
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -223,10 +229,14 @@ RUN set -eux; \
 -}}
 	; \
 	make install; \
+	\
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	bin="$(readlink -vf /usr/local/bin/python3)"; \
+	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 {{ if is_alpine or is_slim then "" else ( -}}
 	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
-	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -260,10 +270,10 @@ RUN set -eux; \
 	apk del --no-network .build-deps; \
 {{ ) else ( -}}
 	ldconfig; \
-{{ if is_slim then ( -}}
 	\
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
+{{ if is_slim then ( -}}
 	find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec ldd '{}' ';' \
 		| awk '/=>/ { print $(NF-1) }' \
 		| sort -u \
@@ -272,9 +282,9 @@ RUN set -eux; \
 		| sort -u \
 		| xargs -r apt-mark manual \
 	; \
+{{ ) else "" end -}}
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
-{{ ) else "" end -}}
 {{ ) end -}}
 	\
 	python3 --version

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -172,10 +172,9 @@ RUN set -eux; \
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
 {{ ) else "" end -}}
-# \$ because of the double quotes in the shell to prevent interpolation
-# $$ for make to not interpret the $O
-# " because it needs the ' around the path, and '"'"' instead is 🤢
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'{{ if is_slim or is_alpine then ",--strip-all" else "" end }}" \
+{{ if is_slim or is_alpine then ( -}}
+		LDFLAGS="-Wl,--strip-all" \
+{{ ) else "" end -}}
 {{ if env.version == "3.7" then ( -}}
 # setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
 		PROFILE_TASK='-m test.regrtest --pgo \


### PR DESCRIPTION
This reverts https://github.com/docker-library/python/issues/785 and then only changes rpath for python3.x binaries and not the libraries in `/usr/local/lib/python3.x/lib-dynload/` since they use system libraries like libssl (so `$ORIGIN/../lib` doesn't work for them).

Hopefully this should also fix issues like #786 or #787 

Broken, current version:
```console
$ docker run -it --rm python:3.9 bash
root@8f5b65b7cd6b:/# readelf --dynamic /usr/local/lib/python3.9/lib-dynload/_ssl.cpython-39-x86_64-linux-gnu.so

Dynamic section at offset 0x24d58 contains 28 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libssl.so.1.1]
 0x0000000000000001 (NEEDED)             Shared library: [libcrypto.so.1.1]
 0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x000000000000001d (RUNPATH)            Library runpath: [/../lib:$ORIGIN/../lib]
...
root@8f5b65b7cd6b:/# # but ldd somehow still works 🤷
root@8f5b65b7cd6b:/# ldd /usr/local/lib/python3.9/lib-dynload/_ssl.cpython-39-x86_64-linux-gnu.so
	linux-vdso.so.1 (0x00007fff459dd000)
	libssl.so.1.1 => /usr/lib/x86_64-linux-gnu/libssl.so.1.1 (0x00007fabee010000)
	libcrypto.so.1.1 => /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 (0x00007fabedd1c000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fabedcfa000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fabedb25000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fabedb1f000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fabee0da000)
```
