### PR TITLE
Use the linker to set rpath on just the python binary

### DIFF
--- a/3.10/alpine3.16/Dockerfile
+++ b/3.10/alpine3.16/Dockerfile
@@ -45,7 +45,6 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
-		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -88,11 +87,6 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.10/alpine3.16/Dockerfile
+++ b/3.10/alpine3.16/Dockerfile
@@ -80,20 +80,22 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
-	make -j "$nproc" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,--strip-all" \
+	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
+	LDFLAGS="-Wl,--strip-all"; \
+	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
-# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.10/alpine3.16/Dockerfile
+++ b/3.10/alpine3.16/Dockerfile
@@ -86,6 +86,16 @@ RUN set -eux; \
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
+# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
+		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.10/alpine3.17/Dockerfile
+++ b/3.10/alpine3.17/Dockerfile
@@ -45,7 +45,6 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
-		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -88,11 +87,6 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.10/alpine3.17/Dockerfile
+++ b/3.10/alpine3.17/Dockerfile
@@ -80,20 +80,22 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
-	make -j "$nproc" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,--strip-all" \
+	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
+	LDFLAGS="-Wl,--strip-all"; \
+	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
-# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.10/alpine3.17/Dockerfile
+++ b/3.10/alpine3.17/Dockerfile
@@ -86,6 +86,16 @@ RUN set -eux; \
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
+# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
+		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.10/bullseye/Dockerfile
+++ b/3.10/bullseye/Dockerfile
@@ -54,6 +54,13 @@ RUN set -eux; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		python \
+	; \
 	make install; \
 	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701

--- a/3.10/bullseye/Dockerfile
+++ b/3.10/bullseye/Dockerfile
@@ -53,12 +53,17 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.10/bullseye/Dockerfile
+++ b/3.10/bullseye/Dockerfile
@@ -28,12 +28,6 @@ ENV PYTHON_VERSION 3.10.9
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		patchelf \
-	; \
-	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -62,12 +56,8 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
-	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
+	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -83,11 +73,6 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
-	\
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.10/buster/Dockerfile
+++ b/3.10/buster/Dockerfile
@@ -54,6 +54,13 @@ RUN set -eux; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		python \
+	; \
 	make install; \
 	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701

--- a/3.10/buster/Dockerfile
+++ b/3.10/buster/Dockerfile
@@ -53,12 +53,17 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.10/buster/Dockerfile
+++ b/3.10/buster/Dockerfile
@@ -28,12 +28,6 @@ ENV PYTHON_VERSION 3.10.9
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		patchelf \
-	; \
-	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -62,12 +56,8 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
-	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
+	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -83,11 +73,6 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
-	\
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.10/slim-bullseye/Dockerfile
+++ b/3.10/slim-bullseye/Dockerfile
@@ -77,14 +77,19 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
+	LDFLAGS="-Wl,--strip-all"; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.10/slim-bullseye/Dockerfile
+++ b/3.10/slim-bullseye/Dockerfile
@@ -80,6 +80,13 @@ RUN set -eux; \
 	make -j "$nproc" \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.10/slim-bullseye/Dockerfile
+++ b/3.10/slim-bullseye/Dockerfile
@@ -46,7 +46,6 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
-		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -82,11 +81,6 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.10/slim-buster/Dockerfile
+++ b/3.10/slim-buster/Dockerfile
@@ -77,14 +77,19 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
+	LDFLAGS="-Wl,--strip-all"; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.10/slim-buster/Dockerfile
+++ b/3.10/slim-buster/Dockerfile
@@ -80,6 +80,13 @@ RUN set -eux; \
 	make -j "$nproc" \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.10/slim-buster/Dockerfile
+++ b/3.10/slim-buster/Dockerfile
@@ -46,7 +46,6 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
-		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -82,11 +81,6 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.11/alpine3.16/Dockerfile
+++ b/3.11/alpine3.16/Dockerfile
@@ -45,7 +45,6 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
-		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -88,11 +87,6 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.11/alpine3.16/Dockerfile
+++ b/3.11/alpine3.16/Dockerfile
@@ -80,20 +80,22 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
-	make -j "$nproc" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,--strip-all" \
+	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
+	LDFLAGS="-Wl,--strip-all"; \
+	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
-# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.11/alpine3.16/Dockerfile
+++ b/3.11/alpine3.16/Dockerfile
@@ -86,6 +86,16 @@ RUN set -eux; \
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
+# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
+		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.11/alpine3.17/Dockerfile
+++ b/3.11/alpine3.17/Dockerfile
@@ -45,7 +45,6 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
-		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -88,11 +87,6 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.11/alpine3.17/Dockerfile
+++ b/3.11/alpine3.17/Dockerfile
@@ -80,20 +80,22 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
-	make -j "$nproc" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,--strip-all" \
+	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
+	LDFLAGS="-Wl,--strip-all"; \
+	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
-# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.11/alpine3.17/Dockerfile
+++ b/3.11/alpine3.17/Dockerfile
@@ -86,6 +86,16 @@ RUN set -eux; \
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
+# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
+		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.11/bullseye/Dockerfile
+++ b/3.11/bullseye/Dockerfile
@@ -28,12 +28,6 @@ ENV PYTHON_VERSION 3.11.1
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		patchelf \
-	; \
-	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -62,12 +56,8 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
-	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
+	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -83,11 +73,6 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
-	\
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.11/bullseye/Dockerfile
+++ b/3.11/bullseye/Dockerfile
@@ -54,6 +54,13 @@ RUN set -eux; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		python \
+	; \
 	make install; \
 	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701

--- a/3.11/bullseye/Dockerfile
+++ b/3.11/bullseye/Dockerfile
@@ -53,12 +53,17 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.11/buster/Dockerfile
+++ b/3.11/buster/Dockerfile
@@ -28,12 +28,6 @@ ENV PYTHON_VERSION 3.11.1
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		patchelf \
-	; \
-	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -62,12 +56,8 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
-	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
+	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -83,11 +73,6 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
-	\
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.11/buster/Dockerfile
+++ b/3.11/buster/Dockerfile
@@ -54,6 +54,13 @@ RUN set -eux; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		python \
+	; \
 	make install; \
 	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701

--- a/3.11/buster/Dockerfile
+++ b/3.11/buster/Dockerfile
@@ -53,12 +53,17 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.11/slim-bullseye/Dockerfile
+++ b/3.11/slim-bullseye/Dockerfile
@@ -77,14 +77,19 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
+	LDFLAGS="-Wl,--strip-all"; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.11/slim-bullseye/Dockerfile
+++ b/3.11/slim-bullseye/Dockerfile
@@ -80,6 +80,13 @@ RUN set -eux; \
 	make -j "$nproc" \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.11/slim-bullseye/Dockerfile
+++ b/3.11/slim-bullseye/Dockerfile
@@ -46,7 +46,6 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
-		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -82,11 +81,6 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.11/slim-buster/Dockerfile
+++ b/3.11/slim-buster/Dockerfile
@@ -77,14 +77,19 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
+	LDFLAGS="-Wl,--strip-all"; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.11/slim-buster/Dockerfile
+++ b/3.11/slim-buster/Dockerfile
@@ -80,6 +80,13 @@ RUN set -eux; \
 	make -j "$nproc" \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.11/slim-buster/Dockerfile
+++ b/3.11/slim-buster/Dockerfile
@@ -46,7 +46,6 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
-		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -82,11 +81,6 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.12-rc/alpine3.16/Dockerfile
+++ b/3.12-rc/alpine3.16/Dockerfile
@@ -45,7 +45,6 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
-		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -88,11 +87,6 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.12-rc/alpine3.16/Dockerfile
+++ b/3.12-rc/alpine3.16/Dockerfile
@@ -80,20 +80,22 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
-	make -j "$nproc" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,--strip-all" \
+	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
+	LDFLAGS="-Wl,--strip-all"; \
+	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
-# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.12-rc/alpine3.16/Dockerfile
+++ b/3.12-rc/alpine3.16/Dockerfile
@@ -86,6 +86,16 @@ RUN set -eux; \
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
+# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
+		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.12-rc/alpine3.17/Dockerfile
+++ b/3.12-rc/alpine3.17/Dockerfile
@@ -45,7 +45,6 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
-		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -88,11 +87,6 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.12-rc/alpine3.17/Dockerfile
+++ b/3.12-rc/alpine3.17/Dockerfile
@@ -80,20 +80,22 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
-	make -j "$nproc" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,--strip-all" \
+	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
+	LDFLAGS="-Wl,--strip-all"; \
+	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
-# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.12-rc/alpine3.17/Dockerfile
+++ b/3.12-rc/alpine3.17/Dockerfile
@@ -86,6 +86,16 @@ RUN set -eux; \
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
+# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
+		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.12-rc/bullseye/Dockerfile
+++ b/3.12-rc/bullseye/Dockerfile
@@ -28,12 +28,6 @@ ENV PYTHON_VERSION 3.12.0a4
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		patchelf \
-	; \
-	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -62,12 +56,8 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
-	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
+	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -83,11 +73,6 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
-	\
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.12-rc/bullseye/Dockerfile
+++ b/3.12-rc/bullseye/Dockerfile
@@ -54,6 +54,13 @@ RUN set -eux; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		python \
+	; \
 	make install; \
 	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701

--- a/3.12-rc/bullseye/Dockerfile
+++ b/3.12-rc/bullseye/Dockerfile
@@ -53,12 +53,17 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.12-rc/buster/Dockerfile
+++ b/3.12-rc/buster/Dockerfile
@@ -28,12 +28,6 @@ ENV PYTHON_VERSION 3.12.0a4
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		patchelf \
-	; \
-	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -62,12 +56,8 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
-	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
+	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -83,11 +73,6 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
-	\
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.12-rc/buster/Dockerfile
+++ b/3.12-rc/buster/Dockerfile
@@ -54,6 +54,13 @@ RUN set -eux; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		python \
+	; \
 	make install; \
 	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701

--- a/3.12-rc/buster/Dockerfile
+++ b/3.12-rc/buster/Dockerfile
@@ -53,12 +53,17 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.12-rc/slim-bullseye/Dockerfile
+++ b/3.12-rc/slim-bullseye/Dockerfile
@@ -77,14 +77,19 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
+	LDFLAGS="-Wl,--strip-all"; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.12-rc/slim-bullseye/Dockerfile
+++ b/3.12-rc/slim-bullseye/Dockerfile
@@ -80,6 +80,13 @@ RUN set -eux; \
 	make -j "$nproc" \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.12-rc/slim-bullseye/Dockerfile
+++ b/3.12-rc/slim-bullseye/Dockerfile
@@ -46,7 +46,6 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
-		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -82,11 +81,6 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.12-rc/slim-buster/Dockerfile
+++ b/3.12-rc/slim-buster/Dockerfile
@@ -77,14 +77,19 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
+	LDFLAGS="-Wl,--strip-all"; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.12-rc/slim-buster/Dockerfile
+++ b/3.12-rc/slim-buster/Dockerfile
@@ -80,6 +80,13 @@ RUN set -eux; \
 	make -j "$nproc" \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.12-rc/slim-buster/Dockerfile
+++ b/3.12-rc/slim-buster/Dockerfile
@@ -46,7 +46,6 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
-		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -82,11 +81,6 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.7/alpine3.16/Dockerfile
+++ b/3.7/alpine3.16/Dockerfile
@@ -121,6 +121,16 @@ RUN set -eux; \
 			test_unicode \
 		' \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
+# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
+		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.7/alpine3.16/Dockerfile
+++ b/3.7/alpine3.16/Dockerfile
@@ -79,56 +79,58 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
-	make -j "$nproc" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,--strip-all" \
+	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
+	LDFLAGS="-Wl,--strip-all"; \
 # setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
-		PROFILE_TASK='-m test.regrtest --pgo \
-			test_array \
-			test_base64 \
-			test_binascii \
-			test_binhex \
-			test_binop \
-			test_bytes \
-			test_c_locale_coercion \
-			test_class \
-			test_cmath \
-			test_codecs \
-			test_compile \
-			test_complex \
-			test_csv \
-			test_decimal \
-			test_dict \
-			test_float \
-			test_fstring \
-			test_hashlib \
-			test_io \
-			test_iter \
-			test_json \
-			test_long \
-			test_math \
-			test_memoryview \
-			test_pickle \
-			test_re \
-			test_set \
-			test_slice \
-			test_struct \
-			test_threading \
-			test_time \
-			test_traceback \
-			test_unicode \
-		' \
+	PROFILE_TASK='-m test.regrtest --pgo \
+		test_array \
+		test_base64 \
+		test_binascii \
+		test_binhex \
+		test_binop \
+		test_bytes \
+		test_c_locale_coercion \
+		test_class \
+		test_cmath \
+		test_codecs \
+		test_compile \
+		test_complex \
+		test_csv \
+		test_decimal \
+		test_dict \
+		test_float \
+		test_fstring \
+		test_hashlib \
+		test_io \
+		test_iter \
+		test_json \
+		test_long \
+		test_math \
+		test_memoryview \
+		test_pickle \
+		test_re \
+		test_set \
+		test_slice \
+		test_struct \
+		test_threading \
+		test_time \
+		test_traceback \
+		test_unicode \
+	'; \
+	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
-# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.7/alpine3.16/Dockerfile
+++ b/3.7/alpine3.16/Dockerfile
@@ -45,7 +45,6 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
-		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -123,11 +122,6 @@ RUN set -eux; \
 		' \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.7/alpine3.17/Dockerfile
+++ b/3.7/alpine3.17/Dockerfile
@@ -121,6 +121,16 @@ RUN set -eux; \
 			test_unicode \
 		' \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
+# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
+		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.7/alpine3.17/Dockerfile
+++ b/3.7/alpine3.17/Dockerfile
@@ -79,56 +79,58 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
-	make -j "$nproc" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,--strip-all" \
+	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
+	LDFLAGS="-Wl,--strip-all"; \
 # setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
-		PROFILE_TASK='-m test.regrtest --pgo \
-			test_array \
-			test_base64 \
-			test_binascii \
-			test_binhex \
-			test_binop \
-			test_bytes \
-			test_c_locale_coercion \
-			test_class \
-			test_cmath \
-			test_codecs \
-			test_compile \
-			test_complex \
-			test_csv \
-			test_decimal \
-			test_dict \
-			test_float \
-			test_fstring \
-			test_hashlib \
-			test_io \
-			test_iter \
-			test_json \
-			test_long \
-			test_math \
-			test_memoryview \
-			test_pickle \
-			test_re \
-			test_set \
-			test_slice \
-			test_struct \
-			test_threading \
-			test_time \
-			test_traceback \
-			test_unicode \
-		' \
+	PROFILE_TASK='-m test.regrtest --pgo \
+		test_array \
+		test_base64 \
+		test_binascii \
+		test_binhex \
+		test_binop \
+		test_bytes \
+		test_c_locale_coercion \
+		test_class \
+		test_cmath \
+		test_codecs \
+		test_compile \
+		test_complex \
+		test_csv \
+		test_decimal \
+		test_dict \
+		test_float \
+		test_fstring \
+		test_hashlib \
+		test_io \
+		test_iter \
+		test_json \
+		test_long \
+		test_math \
+		test_memoryview \
+		test_pickle \
+		test_re \
+		test_set \
+		test_slice \
+		test_struct \
+		test_threading \
+		test_time \
+		test_traceback \
+		test_unicode \
+	'; \
+	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
-# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.7/alpine3.17/Dockerfile
+++ b/3.7/alpine3.17/Dockerfile
@@ -45,7 +45,6 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
-		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -123,11 +122,6 @@ RUN set -eux; \
 		' \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.7/bullseye/Dockerfile
+++ b/3.7/bullseye/Dockerfile
@@ -28,12 +28,6 @@ ENV PYTHON_VERSION 3.7.16
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		patchelf \
-	; \
-	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -97,12 +91,8 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
-	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
+	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -119,11 +109,6 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
-	\
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.7/bullseye/Dockerfile
+++ b/3.7/bullseye/Dockerfile
@@ -89,6 +89,13 @@ RUN set -eux; \
 			test_unicode \
 		' \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		python \
+	; \
 	make install; \
 	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701

--- a/3.7/bullseye/Dockerfile
+++ b/3.7/bullseye/Dockerfile
@@ -51,49 +51,54 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
-	make -j "$nproc" \
 # setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
-		PROFILE_TASK='-m test.regrtest --pgo \
-			test_array \
-			test_base64 \
-			test_binascii \
-			test_binhex \
-			test_binop \
-			test_bytes \
-			test_c_locale_coercion \
-			test_class \
-			test_cmath \
-			test_codecs \
-			test_compile \
-			test_complex \
-			test_csv \
-			test_decimal \
-			test_dict \
-			test_float \
-			test_fstring \
-			test_hashlib \
-			test_io \
-			test_iter \
-			test_json \
-			test_long \
-			test_math \
-			test_memoryview \
-			test_pickle \
-			test_re \
-			test_set \
-			test_slice \
-			test_struct \
-			test_threading \
-			test_time \
-			test_traceback \
-			test_unicode \
-		' \
+	PROFILE_TASK='-m test.regrtest --pgo \
+		test_array \
+		test_base64 \
+		test_binascii \
+		test_binhex \
+		test_binop \
+		test_bytes \
+		test_c_locale_coercion \
+		test_class \
+		test_cmath \
+		test_codecs \
+		test_compile \
+		test_complex \
+		test_csv \
+		test_decimal \
+		test_dict \
+		test_float \
+		test_fstring \
+		test_hashlib \
+		test_io \
+		test_iter \
+		test_json \
+		test_long \
+		test_math \
+		test_memoryview \
+		test_pickle \
+		test_re \
+		test_set \
+		test_slice \
+		test_struct \
+		test_threading \
+		test_time \
+		test_traceback \
+		test_unicode \
+	'; \
+	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.7/buster/Dockerfile
+++ b/3.7/buster/Dockerfile
@@ -28,12 +28,6 @@ ENV PYTHON_VERSION 3.7.16
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		patchelf \
-	; \
-	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -97,12 +91,8 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
-	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
+	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -119,11 +109,6 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
-	\
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.7/buster/Dockerfile
+++ b/3.7/buster/Dockerfile
@@ -89,6 +89,13 @@ RUN set -eux; \
 			test_unicode \
 		' \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		python \
+	; \
 	make install; \
 	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701

--- a/3.7/buster/Dockerfile
+++ b/3.7/buster/Dockerfile
@@ -51,49 +51,54 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
-	make -j "$nproc" \
 # setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
-		PROFILE_TASK='-m test.regrtest --pgo \
-			test_array \
-			test_base64 \
-			test_binascii \
-			test_binhex \
-			test_binop \
-			test_bytes \
-			test_c_locale_coercion \
-			test_class \
-			test_cmath \
-			test_codecs \
-			test_compile \
-			test_complex \
-			test_csv \
-			test_decimal \
-			test_dict \
-			test_float \
-			test_fstring \
-			test_hashlib \
-			test_io \
-			test_iter \
-			test_json \
-			test_long \
-			test_math \
-			test_memoryview \
-			test_pickle \
-			test_re \
-			test_set \
-			test_slice \
-			test_struct \
-			test_threading \
-			test_time \
-			test_traceback \
-			test_unicode \
-		' \
+	PROFILE_TASK='-m test.regrtest --pgo \
+		test_array \
+		test_base64 \
+		test_binascii \
+		test_binhex \
+		test_binop \
+		test_bytes \
+		test_c_locale_coercion \
+		test_class \
+		test_cmath \
+		test_codecs \
+		test_compile \
+		test_complex \
+		test_csv \
+		test_decimal \
+		test_dict \
+		test_float \
+		test_fstring \
+		test_hashlib \
+		test_io \
+		test_iter \
+		test_json \
+		test_long \
+		test_math \
+		test_memoryview \
+		test_pickle \
+		test_re \
+		test_set \
+		test_slice \
+		test_struct \
+		test_threading \
+		test_time \
+		test_traceback \
+		test_unicode \
+	'; \
+	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.7/slim-bullseye/Dockerfile
+++ b/3.7/slim-bullseye/Dockerfile
@@ -115,6 +115,13 @@ RUN set -eux; \
 			test_unicode \
 		' \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.7/slim-bullseye/Dockerfile
+++ b/3.7/slim-bullseye/Dockerfile
@@ -76,50 +76,55 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
-	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
+	LDFLAGS="-Wl,--strip-all"; \
 # setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
-		PROFILE_TASK='-m test.regrtest --pgo \
-			test_array \
-			test_base64 \
-			test_binascii \
-			test_binhex \
-			test_binop \
-			test_bytes \
-			test_c_locale_coercion \
-			test_class \
-			test_cmath \
-			test_codecs \
-			test_compile \
-			test_complex \
-			test_csv \
-			test_decimal \
-			test_dict \
-			test_float \
-			test_fstring \
-			test_hashlib \
-			test_io \
-			test_iter \
-			test_json \
-			test_long \
-			test_math \
-			test_memoryview \
-			test_pickle \
-			test_re \
-			test_set \
-			test_slice \
-			test_struct \
-			test_threading \
-			test_time \
-			test_traceback \
-			test_unicode \
-		' \
+	PROFILE_TASK='-m test.regrtest --pgo \
+		test_array \
+		test_base64 \
+		test_binascii \
+		test_binhex \
+		test_binop \
+		test_bytes \
+		test_c_locale_coercion \
+		test_class \
+		test_cmath \
+		test_codecs \
+		test_compile \
+		test_complex \
+		test_csv \
+		test_decimal \
+		test_dict \
+		test_float \
+		test_fstring \
+		test_hashlib \
+		test_io \
+		test_iter \
+		test_json \
+		test_long \
+		test_math \
+		test_memoryview \
+		test_pickle \
+		test_re \
+		test_set \
+		test_slice \
+		test_struct \
+		test_threading \
+		test_time \
+		test_traceback \
+		test_unicode \
+	'; \
+	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.7/slim-bullseye/Dockerfile
+++ b/3.7/slim-bullseye/Dockerfile
@@ -46,7 +46,6 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
-		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -117,11 +116,6 @@ RUN set -eux; \
 		' \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.7/slim-buster/Dockerfile
+++ b/3.7/slim-buster/Dockerfile
@@ -115,6 +115,13 @@ RUN set -eux; \
 			test_unicode \
 		' \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.7/slim-buster/Dockerfile
+++ b/3.7/slim-buster/Dockerfile
@@ -76,50 +76,55 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
-	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
+	LDFLAGS="-Wl,--strip-all"; \
 # setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
-		PROFILE_TASK='-m test.regrtest --pgo \
-			test_array \
-			test_base64 \
-			test_binascii \
-			test_binhex \
-			test_binop \
-			test_bytes \
-			test_c_locale_coercion \
-			test_class \
-			test_cmath \
-			test_codecs \
-			test_compile \
-			test_complex \
-			test_csv \
-			test_decimal \
-			test_dict \
-			test_float \
-			test_fstring \
-			test_hashlib \
-			test_io \
-			test_iter \
-			test_json \
-			test_long \
-			test_math \
-			test_memoryview \
-			test_pickle \
-			test_re \
-			test_set \
-			test_slice \
-			test_struct \
-			test_threading \
-			test_time \
-			test_traceback \
-			test_unicode \
-		' \
+	PROFILE_TASK='-m test.regrtest --pgo \
+		test_array \
+		test_base64 \
+		test_binascii \
+		test_binhex \
+		test_binop \
+		test_bytes \
+		test_c_locale_coercion \
+		test_class \
+		test_cmath \
+		test_codecs \
+		test_compile \
+		test_complex \
+		test_csv \
+		test_decimal \
+		test_dict \
+		test_float \
+		test_fstring \
+		test_hashlib \
+		test_io \
+		test_iter \
+		test_json \
+		test_long \
+		test_math \
+		test_memoryview \
+		test_pickle \
+		test_re \
+		test_set \
+		test_slice \
+		test_struct \
+		test_threading \
+		test_time \
+		test_traceback \
+		test_unicode \
+	'; \
+	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.7/slim-buster/Dockerfile
+++ b/3.7/slim-buster/Dockerfile
@@ -46,7 +46,6 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
-		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -117,11 +116,6 @@ RUN set -eux; \
 		' \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.8/alpine3.16/Dockerfile
+++ b/3.8/alpine3.16/Dockerfile
@@ -45,7 +45,6 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
-		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -87,11 +86,6 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.8/alpine3.16/Dockerfile
+++ b/3.8/alpine3.16/Dockerfile
@@ -85,6 +85,16 @@ RUN set -eux; \
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
+# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
+		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.8/alpine3.16/Dockerfile
+++ b/3.8/alpine3.16/Dockerfile
@@ -79,20 +79,22 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
-	make -j "$nproc" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,--strip-all" \
+	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
+	LDFLAGS="-Wl,--strip-all"; \
+	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
-# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.8/alpine3.17/Dockerfile
+++ b/3.8/alpine3.17/Dockerfile
@@ -45,7 +45,6 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
-		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -87,11 +86,6 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.8/alpine3.17/Dockerfile
+++ b/3.8/alpine3.17/Dockerfile
@@ -85,6 +85,16 @@ RUN set -eux; \
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
+# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
+		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.8/alpine3.17/Dockerfile
+++ b/3.8/alpine3.17/Dockerfile
@@ -79,20 +79,22 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
-	make -j "$nproc" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,--strip-all" \
+	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
+	LDFLAGS="-Wl,--strip-all"; \
+	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
-# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.8/bullseye/Dockerfile
+++ b/3.8/bullseye/Dockerfile
@@ -52,12 +52,17 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.8/bullseye/Dockerfile
+++ b/3.8/bullseye/Dockerfile
@@ -53,6 +53,13 @@ RUN set -eux; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		python \
+	; \
 	make install; \
 	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701

--- a/3.8/bullseye/Dockerfile
+++ b/3.8/bullseye/Dockerfile
@@ -28,12 +28,6 @@ ENV PYTHON_VERSION 3.8.16
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		patchelf \
-	; \
-	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -61,12 +55,8 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
-	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
+	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -83,11 +73,6 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
-	\
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.8/buster/Dockerfile
+++ b/3.8/buster/Dockerfile
@@ -52,12 +52,17 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.8/buster/Dockerfile
+++ b/3.8/buster/Dockerfile
@@ -53,6 +53,13 @@ RUN set -eux; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		python \
+	; \
 	make install; \
 	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701

--- a/3.8/buster/Dockerfile
+++ b/3.8/buster/Dockerfile
@@ -28,12 +28,6 @@ ENV PYTHON_VERSION 3.8.16
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		patchelf \
-	; \
-	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -61,12 +55,8 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
-	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
+	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -83,11 +73,6 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
-	\
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.8/slim-bullseye/Dockerfile
+++ b/3.8/slim-bullseye/Dockerfile
@@ -46,7 +46,6 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
-		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -81,11 +80,6 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.8/slim-bullseye/Dockerfile
+++ b/3.8/slim-bullseye/Dockerfile
@@ -76,14 +76,19 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
+	LDFLAGS="-Wl,--strip-all"; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.8/slim-bullseye/Dockerfile
+++ b/3.8/slim-bullseye/Dockerfile
@@ -79,6 +79,13 @@ RUN set -eux; \
 	make -j "$nproc" \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.8/slim-buster/Dockerfile
+++ b/3.8/slim-buster/Dockerfile
@@ -46,7 +46,6 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
-		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -81,11 +80,6 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.8/slim-buster/Dockerfile
+++ b/3.8/slim-buster/Dockerfile
@@ -76,14 +76,19 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
+	LDFLAGS="-Wl,--strip-all"; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.8/slim-buster/Dockerfile
+++ b/3.8/slim-buster/Dockerfile
@@ -79,6 +79,13 @@ RUN set -eux; \
 	make -j "$nproc" \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.9/alpine3.16/Dockerfile
+++ b/3.9/alpine3.16/Dockerfile
@@ -45,7 +45,6 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
-		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -87,11 +86,6 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.9/alpine3.16/Dockerfile
+++ b/3.9/alpine3.16/Dockerfile
@@ -85,6 +85,16 @@ RUN set -eux; \
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
+# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
+		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.9/alpine3.16/Dockerfile
+++ b/3.9/alpine3.16/Dockerfile
@@ -79,20 +79,22 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
-	make -j "$nproc" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,--strip-all" \
+	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
+	LDFLAGS="-Wl,--strip-all"; \
+	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
-# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.9/alpine3.17/Dockerfile
+++ b/3.9/alpine3.17/Dockerfile
@@ -45,7 +45,6 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
-		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -87,11 +86,6 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.9/alpine3.17/Dockerfile
+++ b/3.9/alpine3.17/Dockerfile
@@ -85,6 +85,16 @@ RUN set -eux; \
 		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
+# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
+		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.9/alpine3.17/Dockerfile
+++ b/3.9/alpine3.17/Dockerfile
@@ -79,20 +79,22 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
-	make -j "$nproc" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,--strip-all" \
+	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
+	LDFLAGS="-Wl,--strip-all"; \
+	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
-# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.9/bullseye/Dockerfile
+++ b/3.9/bullseye/Dockerfile
@@ -52,12 +52,17 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.9/bullseye/Dockerfile
+++ b/3.9/bullseye/Dockerfile
@@ -53,6 +53,13 @@ RUN set -eux; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		python \
+	; \
 	make install; \
 	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701

--- a/3.9/bullseye/Dockerfile
+++ b/3.9/bullseye/Dockerfile
@@ -28,12 +28,6 @@ ENV PYTHON_VERSION 3.9.16
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		patchelf \
-	; \
-	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -61,12 +55,8 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
-	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
+	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -82,11 +72,6 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
-	\
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.9/buster/Dockerfile
+++ b/3.9/buster/Dockerfile
@@ -52,12 +52,17 @@ RUN set -eux; \
 	; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.9/buster/Dockerfile
+++ b/3.9/buster/Dockerfile
@@ -53,6 +53,13 @@ RUN set -eux; \
 	nproc="$(nproc)"; \
 	make -j "$nproc" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'" \
+		python \
+	; \
 	make install; \
 	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701

--- a/3.9/buster/Dockerfile
+++ b/3.9/buster/Dockerfile
@@ -28,12 +28,6 @@ ENV PYTHON_VERSION 3.9.16
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		patchelf \
-	; \
-	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -61,12 +55,8 @@ RUN set -eux; \
 	; \
 	make install; \
 	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
-	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
+	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -82,11 +72,6 @@ RUN set -eux; \
 	; \
 	\
 	ldconfig; \
-	\
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	python3 --version
 

--- a/3.9/slim-bullseye/Dockerfile
+++ b/3.9/slim-bullseye/Dockerfile
@@ -46,7 +46,6 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
-		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -81,11 +80,6 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.9/slim-bullseye/Dockerfile
+++ b/3.9/slim-bullseye/Dockerfile
@@ -76,14 +76,19 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
+	LDFLAGS="-Wl,--strip-all"; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.9/slim-bullseye/Dockerfile
+++ b/3.9/slim-bullseye/Dockerfile
@@ -79,6 +79,13 @@ RUN set -eux; \
 	make -j "$nproc" \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/3.9/slim-buster/Dockerfile
+++ b/3.9/slim-buster/Dockerfile
@@ -46,7 +46,6 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
-		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
@@ -81,11 +80,6 @@ RUN set -eux; \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 	\
 	cd /; \
 	rm -rf /usr/src/python; \

--- a/3.9/slim-buster/Dockerfile
+++ b/3.9/slim-buster/Dockerfile
@@ -76,14 +76,19 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
+	LDFLAGS="-Wl,--strip-all"; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/3.9/slim-buster/Dockerfile
+++ b/3.9/slim-buster/Dockerfile
@@ -79,6 +79,13 @@ RUN set -eux; \
 	make -j "$nproc" \
 		LDFLAGS="-Wl,--strip-all" \
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib',--strip-all" \
+		python \
+	; \
 	make install; \
 	\
 	cd /; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -166,72 +166,72 @@ RUN set -eux; \
 		--without-ensurepip \
 	; \
 	nproc="$(nproc)"; \
-	make -j "$nproc" \
 {{ if is_alpine then ( -}}
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
+	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
 {{ ) else "" end -}}
 {{ if is_slim or is_alpine then ( -}}
-		LDFLAGS="-Wl,--strip-all" \
+	LDFLAGS="-Wl,--strip-all"; \
 {{ ) else "" end -}}
 {{ if env.version == "3.7" then ( -}}
 # setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
-		PROFILE_TASK='-m test.regrtest --pgo \
-			test_array \
-			test_base64 \
-			test_binascii \
-			test_binhex \
-			test_binop \
-			test_bytes \
-			test_c_locale_coercion \
-			test_class \
-			test_cmath \
-			test_codecs \
-			test_compile \
-			test_complex \
-			test_csv \
-			test_decimal \
-			test_dict \
-			test_float \
-			test_fstring \
-			test_hashlib \
-			test_io \
-			test_iter \
-			test_json \
-			test_long \
-			test_math \
-			test_memoryview \
-			test_pickle \
-			test_re \
-			test_set \
-			test_slice \
-			test_struct \
-			test_threading \
-			test_time \
-			test_traceback \
-			test_unicode \
-		' \
+	PROFILE_TASK='-m test.regrtest --pgo \
+		test_array \
+		test_base64 \
+		test_binascii \
+		test_binhex \
+		test_binop \
+		test_bytes \
+		test_c_locale_coercion \
+		test_class \
+		test_cmath \
+		test_codecs \
+		test_compile \
+		test_complex \
+		test_csv \
+		test_decimal \
+		test_dict \
+		test_float \
+		test_fstring \
+		test_hashlib \
+		test_io \
+		test_iter \
+		test_json \
+		test_long \
+		test_math \
+		test_memoryview \
+		test_pickle \
+		test_re \
+		test_set \
+		test_slice \
+		test_struct \
+		test_threading \
+		test_time \
+		test_traceback \
+		test_unicode \
+	'; \
 {{
-	) else
-		# PROFILE_TASK has a reasonable default starting in 3.8+; see:
-		#   https://bugs.python.org/issue36044
-		#   https://github.com/python/cpython/pull/14702
-		#   https://github.com/python/cpython/pull/14910
-		""
-	end
+) else
+	# PROFILE_TASK has a reasonable default starting in 3.8+; see:
+	#   https://bugs.python.org/issue36044
+	#   https://github.com/python/cpython/pull/14702
+	#   https://github.com/python/cpython/pull/14910
+	""
+end
 -}}
+	make -j "$nproc" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:-}" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 	; \
 # https://github.com/docker-library/python/issues/784
 # prevent accidental usage of a system installed libpython of the same version
 	rm python; \
 	make -j "$nproc" \
-{{ if is_alpine then ( -}}
-# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
-# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
-		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-{{ ) else "" end -}}
-		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'{{ if is_slim or is_alpine then ",--strip-all" else "" end }}" \
+		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+		"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+		"PROFILE_TASK=${PROFILE_TASK:-}" \
 		python \
 	; \
 	make install; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -222,6 +222,18 @@ RUN set -eux; \
 	end
 -}}
 	; \
+# https://github.com/docker-library/python/issues/784
+# prevent accidental usage of a system installed libpython of the same version
+	rm python; \
+	make -j "$nproc" \
+{{ if is_alpine then ( -}}
+# set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
+# https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
+		EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
+{{ ) else "" end -}}
+		LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib'{{ if is_slim or is_alpine then ",--strip-all" else "" end }}" \
+		python \
+	; \
 	make install; \
 {{ if is_alpine or is_slim then "" else ( -}}
 	\

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -99,7 +99,6 @@ RUN set -eux; \
 		make \
 		ncurses-dev \
 		openssl-dev \
-		patchelf \
 		pax-utils \
 		readline-dev \
 		sqlite-dev \
@@ -111,11 +110,10 @@ RUN set -eux; \
 		zlib-dev \
 	; \
 	\
-{{ ) else ( -}}
+{{ ) elif is_slim then ( -}}
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-{{ if is_slim then ( -}}
 		dpkg-dev \
 		gcc \
 		gnupg dirmngr \
@@ -131,18 +129,14 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
-		patchelf \
 		tk-dev \
 		uuid-dev \
 		wget \
 		xz-utils \
 		zlib1g-dev \
-{{ ) else ( -}}
-		patchelf \
-{{ ) end -}}
 	; \
 	\
-{{ ) end -}}
+{{ ) else "" end -}}
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
@@ -229,14 +223,10 @@ RUN set -eux; \
 -}}
 	; \
 	make install; \
-	\
-# https://github.com/docker-library/python/issues/784
-# prevent accidental usage of a system installed libpython of the same version
-	bin="$(readlink -vf /usr/local/bin/python3)"; \
-	patchelf --set-rpath '$ORIGIN/../lib' "$bin"; \
 {{ if is_alpine or is_slim then "" else ( -}}
 	\
 # enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
+	bin="$(readlink -ve /usr/local/bin/python3)"; \
 	dir="$(dirname "$bin")"; \
 	mkdir -p "/usr/share/gdb/auto-load/$dir"; \
 	cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
@@ -270,10 +260,10 @@ RUN set -eux; \
 	apk del --no-network .build-deps; \
 {{ ) else ( -}}
 	ldconfig; \
+{{ if is_slim then ( -}}
 	\
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
-{{ if is_slim then ( -}}
 	find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec ldd '{}' ';' \
 		| awk '/=>/ { print $(NF-1) }' \
 		| sort -u \
@@ -282,9 +272,9 @@ RUN set -eux; \
 		| sort -u \
 		| xargs -r apt-mark manual \
 	; \
-{{ ) else "" end -}}
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+{{ ) else "" end -}}
 {{ ) end -}}
 	\
 	python3 --version


### PR DESCRIPTION
First build Python. Then re-build just the python executable with the linker flag `-rpath=$ORIGIN/../lib`. With this process, the python binary does not trigger a Rosetta error.

This Dockerfile demonstrates that only the python executable has a runpath set on it. The Python library and other .so files that are built as part of building Python do not have a runpath on them.

<details><summary>Dockerfile</summary>
<p>

```Dockerfile
FROM python:3.10-slim-bullseye

SHELL [ "/bin/bash", "-eux", "-c" ]

RUN \
    apt-get update; \
    apt-get install -y --no-install-recommends binutils patchelf; \
    rm -rf /var/lib/apt/lists/*

RUN \
    /usr/local/bin/python3.10 -V; \
    patchelf --print-rpath /usr/local/bin/python3.10; \
    patchelf --print-rpath /usr/local/lib/libpython3.10.so.1.0; \
    find /usr/local/lib/python3.10 -name '*.so' -print -exec patchelf --print-rpath '{}' \; ; \
    readelf -d /usr/local/bin/python3.10; \
    readelf -d /usr/local/lib/libpython3.10.so.1.0
```

</p>
</details>

<details><summary>docker buildx build --platform=linux/amd64 --progress=plain .</summary>
<p>

```
#6 [3/3] RUN     /usr/local/bin/python3.10 -V;     patchelf --print-rpath /usr/local/bin/python3.10;     patchelf --print-rpath /usr/local/lib/libpython3.10.so.1.0;     find /usr/local/lib/python3.10 -name '*.so' -print -exec patchelf --print-rpath '{}' ; ;     readelf -d /usr/local/bin/python3.10;     readelf -d /usr/local/lib/libpython3.10.so.1.0
#6 0.358 + /usr/local/bin/python3.10 -V
#6 0.374 Python 3.10.9
#6 0.375 + patchelf --print-rpath /usr/local/bin/python3.10
#6 0.389 $ORIGIN/../lib
#6 0.389 + patchelf --print-rpath /usr/local/lib/libpython3.10.so.1.0
#6 0.407
#6 0.409 + find /usr/local/lib/python3.10 -name '*.so' -print -exec patchelf --print-rpath '{}' ';'
#6 0.431 /usr/local/lib/python3.10/lib-dynload/_datetime.cpython-310-x86_64-linux-gnu.so
#6 0.445
#6 0.445 /usr/local/lib/python3.10/lib-dynload/_multibytecodec.cpython-310-x86_64-linux-gnu.so
#6 0.459
#6 0.459 /usr/local/lib/python3.10/lib-dynload/_statistics.cpython-310-x86_64-linux-gnu.so
#6 0.472
#6 0.473 /usr/local/lib/python3.10/lib-dynload/_sha1.cpython-310-x86_64-linux-gnu.so
#6 0.486
#6 0.486 /usr/local/lib/python3.10/lib-dynload/_pickle.cpython-310-x86_64-linux-gnu.so
#6 0.500
#6 0.500 /usr/local/lib/python3.10/lib-dynload/_opcode.cpython-310-x86_64-linux-gnu.so
#6 0.515
#6 0.515 /usr/local/lib/python3.10/lib-dynload/_sha3.cpython-310-x86_64-linux-gnu.so
#6 0.529
#6 0.530 /usr/local/lib/python3.10/lib-dynload/termios.cpython-310-x86_64-linux-gnu.so
#6 0.543
#6 0.543 /usr/local/lib/python3.10/lib-dynload/select.cpython-310-x86_64-linux-gnu.so
#6 0.557
#6 0.557 /usr/local/lib/python3.10/lib-dynload/_uuid.cpython-310-x86_64-linux-gnu.so
#6 0.570
#6 0.571 /usr/local/lib/python3.10/lib-dynload/_codecs_kr.cpython-310-x86_64-linux-gnu.so
#6 0.584
#6 0.585 /usr/local/lib/python3.10/lib-dynload/_elementtree.cpython-310-x86_64-linux-gnu.so
#6 0.598
#6 0.598 /usr/local/lib/python3.10/lib-dynload/_json.cpython-310-x86_64-linux-gnu.so
#6 0.611
#6 0.612 /usr/local/lib/python3.10/lib-dynload/_sha256.cpython-310-x86_64-linux-gnu.so
#6 0.625
#6 0.626 /usr/local/lib/python3.10/lib-dynload/_sha512.cpython-310-x86_64-linux-gnu.so
#6 0.641
#6 0.641 /usr/local/lib/python3.10/lib-dynload/binascii.cpython-310-x86_64-linux-gnu.so
#6 0.655
#6 0.655 /usr/local/lib/python3.10/lib-dynload/_bz2.cpython-310-x86_64-linux-gnu.so
#6 0.669
#6 0.669 /usr/local/lib/python3.10/lib-dynload/_csv.cpython-310-x86_64-linux-gnu.so
#6 0.683
#6 0.683 /usr/local/lib/python3.10/lib-dynload/zlib.cpython-310-x86_64-linux-gnu.so
#6 0.697
#6 0.697 /usr/local/lib/python3.10/lib-dynload/_decimal.cpython-310-x86_64-linux-gnu.so
#6 0.711
#6 0.712 /usr/local/lib/python3.10/lib-dynload/grp.cpython-310-x86_64-linux-gnu.so
#6 0.725
#6 0.726 /usr/local/lib/python3.10/lib-dynload/math.cpython-310-x86_64-linux-gnu.so
#6 0.741
#6 0.742 /usr/local/lib/python3.10/lib-dynload/_sqlite3.cpython-310-x86_64-linux-gnu.so
#6 0.757
#6 0.757 /usr/local/lib/python3.10/lib-dynload/_gdbm.cpython-310-x86_64-linux-gnu.so
#6 0.771
#6 0.772 /usr/local/lib/python3.10/lib-dynload/_hashlib.cpython-310-x86_64-linux-gnu.so
#6 0.786
#6 0.786 /usr/local/lib/python3.10/lib-dynload/_xxsubinterpreters.cpython-310-x86_64-linux-gnu.so
#6 0.799
#6 0.800 /usr/local/lib/python3.10/lib-dynload/syslog.cpython-310-x86_64-linux-gnu.so
#6 0.813
#6 0.814 /usr/local/lib/python3.10/lib-dynload/_testmultiphase.cpython-310-x86_64-linux-gnu.so
#6 0.827
#6 0.828 /usr/local/lib/python3.10/lib-dynload/_queue.cpython-310-x86_64-linux-gnu.so
#6 0.843
#6 0.843 /usr/local/lib/python3.10/lib-dynload/_codecs_iso2022.cpython-310-x86_64-linux-gnu.so
#6 0.857
#6 0.857 /usr/local/lib/python3.10/lib-dynload/_md5.cpython-310-x86_64-linux-gnu.so
#6 0.871
#6 0.872 /usr/local/lib/python3.10/lib-dynload/_curses_panel.cpython-310-x86_64-linux-gnu.so
#6 0.885
#6 0.885 /usr/local/lib/python3.10/lib-dynload/_asyncio.cpython-310-x86_64-linux-gnu.so
#6 0.899
#6 0.899 /usr/local/lib/python3.10/lib-dynload/_crypt.cpython-310-x86_64-linux-gnu.so
#6 0.913
#6 0.913 /usr/local/lib/python3.10/lib-dynload/audioop.cpython-310-x86_64-linux-gnu.so
#6 0.926
#6 0.927 /usr/local/lib/python3.10/lib-dynload/fcntl.cpython-310-x86_64-linux-gnu.so
#6 0.940
#6 0.940 /usr/local/lib/python3.10/lib-dynload/_testbuffer.cpython-310-x86_64-linux-gnu.so
#6 0.955
#6 0.956 /usr/local/lib/python3.10/lib-dynload/_multiprocessing.cpython-310-x86_64-linux-gnu.so
#6 0.970
#6 0.970 /usr/local/lib/python3.10/lib-dynload/mmap.cpython-310-x86_64-linux-gnu.so
#6 0.983
#6 0.984 /usr/local/lib/python3.10/lib-dynload/_testcapi.cpython-310-x86_64-linux-gnu.so
#6 0.997
#6 0.997 /usr/local/lib/python3.10/lib-dynload/_xxtestfuzz.cpython-310-x86_64-linux-gnu.so
#6 1.011
#6 1.011 /usr/local/lib/python3.10/lib-dynload/_posixsubprocess.cpython-310-x86_64-linux-gnu.so
#6 1.025
#6 1.025 /usr/local/lib/python3.10/lib-dynload/resource.cpython-310-x86_64-linux-gnu.so
#6 1.038
#6 1.039 /usr/local/lib/python3.10/lib-dynload/_blake2.cpython-310-x86_64-linux-gnu.so
#6 1.052
#6 1.052 /usr/local/lib/python3.10/lib-dynload/_contextvars.cpython-310-x86_64-linux-gnu.so
#6 1.066
#6 1.067 /usr/local/lib/python3.10/lib-dynload/readline.cpython-310-x86_64-linux-gnu.so
#6 1.081
#6 1.081 /usr/local/lib/python3.10/lib-dynload/cmath.cpython-310-x86_64-linux-gnu.so
#6 1.095
#6 1.095 /usr/local/lib/python3.10/lib-dynload/array.cpython-310-x86_64-linux-gnu.so
#6 1.109
#6 1.109 /usr/local/lib/python3.10/lib-dynload/_random.cpython-310-x86_64-linux-gnu.so
#6 1.123
#6 1.123 /usr/local/lib/python3.10/lib-dynload/_heapq.cpython-310-x86_64-linux-gnu.so
#6 1.136
#6 1.137 /usr/local/lib/python3.10/lib-dynload/pyexpat.cpython-310-x86_64-linux-gnu.so
#6 1.150
#6 1.150 /usr/local/lib/python3.10/lib-dynload/_ctypes_test.cpython-310-x86_64-linux-gnu.so
#6 1.164
#6 1.164 /usr/local/lib/python3.10/lib-dynload/_lzma.cpython-310-x86_64-linux-gnu.so
#6 1.179
#6 1.180 /usr/local/lib/python3.10/lib-dynload/_zoneinfo.cpython-310-x86_64-linux-gnu.so
#6 1.194
#6 1.194 /usr/local/lib/python3.10/lib-dynload/unicodedata.cpython-310-x86_64-linux-gnu.so
#6 1.209
#6 1.209 /usr/local/lib/python3.10/lib-dynload/ossaudiodev.cpython-310-x86_64-linux-gnu.so
#6 1.223
#6 1.223 /usr/local/lib/python3.10/lib-dynload/_struct.cpython-310-x86_64-linux-gnu.so
#6 1.236
#6 1.237 /usr/local/lib/python3.10/lib-dynload/nis.cpython-310-x86_64-linux-gnu.so
#6 1.250
#6 1.251 /usr/local/lib/python3.10/lib-dynload/_codecs_hk.cpython-310-x86_64-linux-gnu.so
#6 1.264
#6 1.265 /usr/local/lib/python3.10/lib-dynload/_codecs_cn.cpython-310-x86_64-linux-gnu.so
#6 1.280
#6 1.281 /usr/local/lib/python3.10/lib-dynload/_codecs_jp.cpython-310-x86_64-linux-gnu.so
#6 1.295
#6 1.295 /usr/local/lib/python3.10/lib-dynload/_lsprof.cpython-310-x86_64-linux-gnu.so
#6 1.308
#6 1.309 /usr/local/lib/python3.10/lib-dynload/_posixshmem.cpython-310-x86_64-linux-gnu.so
#6 1.322
#6 1.322 /usr/local/lib/python3.10/lib-dynload/_codecs_tw.cpython-310-x86_64-linux-gnu.so
#6 1.336
#6 1.336 /usr/local/lib/python3.10/lib-dynload/_bisect.cpython-310-x86_64-linux-gnu.so
#6 1.350
#6 1.350 /usr/local/lib/python3.10/lib-dynload/_curses.cpython-310-x86_64-linux-gnu.so
#6 1.363
#6 1.364 /usr/local/lib/python3.10/lib-dynload/_socket.cpython-310-x86_64-linux-gnu.so
#6 1.378
#6 1.378 /usr/local/lib/python3.10/lib-dynload/_tkinter.cpython-310-x86_64-linux-gnu.so
#6 1.392
#6 1.393 /usr/local/lib/python3.10/lib-dynload/_testimportmultiple.cpython-310-x86_64-linux-gnu.so
#6 1.407
#6 1.407 /usr/local/lib/python3.10/lib-dynload/_testinternalcapi.cpython-310-x86_64-linux-gnu.so
#6 1.421
#6 1.421 /usr/local/lib/python3.10/lib-dynload/_ssl.cpython-310-x86_64-linux-gnu.so
#6 1.435
#6 1.435 /usr/local/lib/python3.10/lib-dynload/xxlimited.cpython-310-x86_64-linux-gnu.so
#6 1.448
#6 1.449 /usr/local/lib/python3.10/lib-dynload/_ctypes.cpython-310-x86_64-linux-gnu.so
#6 1.462
#6 1.463 /usr/local/lib/python3.10/lib-dynload/xxlimited_35.cpython-310-x86_64-linux-gnu.so
#6 1.476
#6 1.476 /usr/local/lib/python3.10/lib-dynload/spwd.cpython-310-x86_64-linux-gnu.so
#6 1.489
#6 1.495 + readelf -d /usr/local/bin/python3.10
#6 1.513
#6 1.513 Dynamic section at offset 0x2dd8 contains 28 entries:
#6 1.513   Tag        Type                         Name/Value
#6 1.513  0x0000000000000001 (NEEDED)             Shared library: [libpython3.10.so.1.0]
#6 1.513  0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
#6 1.513  0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../lib]
#6 1.513  0x000000000000000c (INIT)               0x1000
#6 1.513  0x000000000000000d (FINI)               0x11b4
#6 1.513  0x0000000000000019 (INIT_ARRAY)         0x3dc8
#6 1.513  0x000000000000001b (INIT_ARRAYSZ)       8 (bytes)
#6 1.513  0x000000000000001a (FINI_ARRAY)         0x3dd0
#6 1.513  0x000000000000001c (FINI_ARRAYSZ)       8 (bytes)
#6 1.513  0x000000006ffffef5 (GNU_HASH)           0x308
#6 1.513  0x0000000000000005 (STRTAB)             0x4d8
#6 1.513  0x0000000000000006 (SYMTAB)             0x358
#6 1.513  0x000000000000000a (STRSZ)              258 (bytes)
#6 1.513  0x000000000000000b (SYMENT)             24 (bytes)
#6 1.513  0x0000000000000015 (DEBUG)              0x0
#6 1.513  0x0000000000000003 (PLTGOT)             0x4000
#6 1.513  0x0000000000000002 (PLTRELSZ)           24 (bytes)
#6 1.513  0x0000000000000014 (PLTREL)             RELA
#6 1.513  0x0000000000000017 (JMPREL)             0x6e0
#6 1.513  0x0000000000000007 (RELA)               0x620
#6 1.513  0x0000000000000008 (RELASZ)             192 (bytes)
#6 1.513  0x0000000000000009 (RELAENT)            24 (bytes)
#6 1.513  0x000000006ffffffb (FLAGS_1)            Flags: PIE
#6 1.513  0x000000006ffffffe (VERNEED)            0x600
#6 1.513  0x000000006fffffff (VERNEEDNUM)         1
#6 1.513  0x000000006ffffff0 (VERSYM)             0x5da
#6 1.513  0x000000006ffffff9 (RELACOUNT)          3
#6 1.513  0x0000000000000000 (NULL)               0x0
#6 1.514 + readelf -d /usr/local/lib/libpython3.10.so.1.0
#6 1.529
#6 1.529 Dynamic section at offset 0x37a608 contains 29 entries:
#6 1.529   Tag        Type                         Name/Value
#6 1.529  0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
#6 1.529  0x0000000000000001 (NEEDED)             Shared library: [libdl.so.2]
#6 1.529  0x0000000000000001 (NEEDED)             Shared library: [libutil.so.1]
#6 1.529  0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
#6 1.529  0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
#6 1.529  0x000000000000000e (SONAME)             Library soname: [libpython3.10.so.1.0]
#6 1.529  0x000000000000000c (INIT)               0x59000
#6 1.529  0x000000000000000d (FINI)               0x27e64c
#6 1.529  0x0000000000000019 (INIT_ARRAY)         0x377b10
#6 1.529  0x000000000000001b (INIT_ARRAYSZ)       8 (bytes)
#6 1.529  0x000000000000001a (FINI_ARRAY)         0x377b18
#6 1.529  0x000000000000001c (FINI_ARRAYSZ)       8 (bytes)
#6 1.529  0x000000006ffffef5 (GNU_HASH)           0x260
#6 1.529  0x0000000000000005 (STRTAB)             0xeee0
#6 1.529  0x0000000000000006 (SYMTAB)             0x3408
#6 1.529  0x000000000000000a (STRSZ)              36620 (bytes)
#6 1.529  0x000000000000000b (SYMENT)             24 (bytes)
#6 1.529  0x0000000000000003 (PLTGOT)             0x37c000
#6 1.529  0x0000000000000002 (PLTRELSZ)           8544 (bytes)
#6 1.529  0x0000000000000014 (PLTREL)             RELA
#6 1.529  0x0000000000000017 (JMPREL)             0x56540
#6 1.529  0x0000000000000007 (RELA)               0x18f50
#6 1.529  0x0000000000000008 (RELASZ)             251376 (bytes)
#6 1.529  0x0000000000000009 (RELAENT)            24 (bytes)
#6 1.529  0x000000006ffffffe (VERNEED)            0x18d80
#6 1.529  0x000000006fffffff (VERNEEDNUM)         5
#6 1.529  0x000000006ffffff0 (VERSYM)             0x17dec
#6 1.529  0x000000006ffffff9 (RELACOUNT)          9730
#6 1.529  0x0000000000000000 (NULL)               0x0
#6 DONE 1.5s
```

<p>
</details>

Fixes #792 