### PR TITLE
Remove mips64le from 3.10 as well (failing to build)

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -134,7 +134,7 @@ for version; do
 		esac
 
 		case "$version" in
-			3.7 | 3.8 | 3.9 | 3.10) ;;
+			3.7 | 3.8 | 3.9) ;;
 			*)
 				# https://github.com/python/cpython/issues/93619 + https://peps.python.org/pep-0011/
 				variantArches="$(sed <<<" $variantArches " -e 's/ mips64le / /g')"


### PR DESCRIPTION
See #765, https://github.com/python/cpython/issues/93619, https://peps.python.org/pep-0011/

```diff
$ diff -u <(bashbrew cat python) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63	2023-02-16 16:58:56.138476872 -0800
+++ /dev/fd/62	2023-02-16 16:58:56.142476909 -0800
@@ -93,12 +93,12 @@
 
 Tags: 3.10.10-bullseye, 3.10-bullseye
 SharedTags: 3.10.10, 3.10
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1a68bced0dc5b7deb6ecd2f7ddacc1089323409d
 Directory: 3.10/bullseye
 
 Tags: 3.10.10-slim-bullseye, 3.10-slim-bullseye, 3.10.10-slim, 3.10-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1a68bced0dc5b7deb6ecd2f7ddacc1089323409d
 Directory: 3.10/slim-bullseye
 
```