### PR TITLE
Enable buildkit to widen test of its use

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -64,6 +64,7 @@ cat <<-EOH
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
+Builder: buildkit
 EOH
 
 # prints "$2$1$3$1...$N"
@@ -165,6 +166,7 @@ for version; do
 		EOE
 		if [[ "$v" == windows/* ]]; then
 			echo "Constraints: $variant"
+			echo 'Builder: classic'
 		fi
 	done
 done


### PR DESCRIPTION
This image is an especially useful test because it includes both Windows _and_ Linux images (compared to most of the other images that have opted in to buildkit explicitly so far).