### PR TITLE
Add Alpine 3.18 variant

### DIFF
--- a/3.10/alpine3.18/Dockerfile
+++ b/3.10/alpine3.18/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.16
+FROM alpine:3.18
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
@@ -21,7 +21,7 @@ RUN set -eux; \
 	;
 
 ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
-ENV PYTHON_VERSION 3.11.3
+ENV PYTHON_VERSION 3.10.11
 
 RUN set -eux; \
 	\
@@ -130,7 +130,7 @@ RUN set -eux; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 22.3.1
+ENV PYTHON_PIP_VERSION 23.0.1
 # https://github.com/docker-library/python/issues/365
 ENV PYTHON_SETUPTOOLS_VERSION 65.5.1
 # https://github.com/pypa/get-pip

--- a/3.11/alpine3.18/Dockerfile
+++ b/3.11/alpine3.18/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.16
+FROM alpine:3.18
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
@@ -20,8 +20,8 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568
-ENV PYTHON_VERSION 3.8.16
+ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
+ENV PYTHON_VERSION 3.11.3
 
 RUN set -eux; \
 	\
@@ -75,6 +75,7 @@ RUN set -eux; \
 		--enable-optimizations \
 		--enable-option-checking=fatal \
 		--enable-shared \
+		--with-lto \
 		--with-system-expat \
 		--without-ensurepip \
 	; \
@@ -106,7 +107,6 @@ RUN set -eux; \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
 			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
-			-o \( -type f -a -name 'wininst-*.exe' \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\
@@ -130,9 +130,9 @@ RUN set -eux; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 22.0.4
+ENV PYTHON_PIP_VERSION 22.3.1
 # https://github.com/docker-library/python/issues/365
-ENV PYTHON_SETUPTOOLS_VERSION 57.5.0
+ENV PYTHON_SETUPTOOLS_VERSION 65.5.1
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/0d8570dc44796f4369b652222cf176b3db6ac70e/public/get-pip.py
 ENV PYTHON_GET_PIP_SHA256 96461deced5c2a487ddc65207ec5a9cffeca0d34e7af7ea1afc470ff0d746207

--- a/3.12-rc/alpine3.18/Dockerfile
+++ b/3.12-rc/alpine3.18/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.16
+FROM alpine:3.18
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
@@ -20,8 +20,8 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
-ENV PYTHON_VERSION 3.7.16
+ENV GPG_KEY 7169605F62C751356D054A26A821E680E5FA6305
+ENV PYTHON_VERSION 3.12.0a7
 
 RUN set -eux; \
 	\
@@ -75,6 +75,7 @@ RUN set -eux; \
 		--enable-optimizations \
 		--enable-option-checking=fatal \
 		--enable-shared \
+		--with-lto \
 		--with-system-expat \
 		--without-ensurepip \
 	; \
@@ -83,42 +84,6 @@ RUN set -eux; \
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
 	LDFLAGS="${LDFLAGS:--Wl},--strip-all"; \
-# setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
-	PROFILE_TASK='-m test.regrtest --pgo \
-		test_array \
-		test_base64 \
-		test_binascii \
-		test_binhex \
-		test_binop \
-		test_bytes \
-		test_c_locale_coercion \
-		test_class \
-		test_cmath \
-		test_codecs \
-		test_compile \
-		test_complex \
-		test_csv \
-		test_decimal \
-		test_dict \
-		test_float \
-		test_fstring \
-		test_hashlib \
-		test_io \
-		test_iter \
-		test_json \
-		test_long \
-		test_math \
-		test_memoryview \
-		test_pickle \
-		test_re \
-		test_set \
-		test_slice \
-		test_struct \
-		test_threading \
-		test_time \
-		test_traceback \
-		test_unicode \
-	'; \
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \
@@ -142,7 +107,6 @@ RUN set -eux; \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
 			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
-			-o \( -type f -a -name 'wininst-*.exe' \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\
@@ -166,9 +130,9 @@ RUN set -eux; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 22.0.4
+ENV PYTHON_PIP_VERSION 23.0.1
 # https://github.com/docker-library/python/issues/365
-ENV PYTHON_SETUPTOOLS_VERSION 57.5.0
+ENV PYTHON_SETUPTOOLS_VERSION 65.5.1
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/0d8570dc44796f4369b652222cf176b3db6ac70e/public/get-pip.py
 ENV PYTHON_GET_PIP_SHA256 96461deced5c2a487ddc65207ec5a9cffeca0d34e7af7ea1afc470ff0d746207

--- a/3.7/alpine3.18/Dockerfile
+++ b/3.7/alpine3.18/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.16
+FROM alpine:3.18
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
@@ -20,8 +20,8 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568
-ENV PYTHON_VERSION 3.9.16
+ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
+ENV PYTHON_VERSION 3.7.16
 
 RUN set -eux; \
 	\
@@ -83,6 +83,42 @@ RUN set -eux; \
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
 	LDFLAGS="${LDFLAGS:--Wl},--strip-all"; \
+# setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
+	PROFILE_TASK='-m test.regrtest --pgo \
+		test_array \
+		test_base64 \
+		test_binascii \
+		test_binhex \
+		test_binop \
+		test_bytes \
+		test_c_locale_coercion \
+		test_class \
+		test_cmath \
+		test_codecs \
+		test_compile \
+		test_complex \
+		test_csv \
+		test_decimal \
+		test_dict \
+		test_float \
+		test_fstring \
+		test_hashlib \
+		test_io \
+		test_iter \
+		test_json \
+		test_long \
+		test_math \
+		test_memoryview \
+		test_pickle \
+		test_re \
+		test_set \
+		test_slice \
+		test_struct \
+		test_threading \
+		test_time \
+		test_traceback \
+		test_unicode \
+	'; \
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \
@@ -106,6 +142,7 @@ RUN set -eux; \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
 			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
+			-o \( -type f -a -name 'wininst-*.exe' \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\
@@ -131,7 +168,7 @@ RUN set -eux; \
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 22.0.4
 # https://github.com/docker-library/python/issues/365
-ENV PYTHON_SETUPTOOLS_VERSION 58.1.0
+ENV PYTHON_SETUPTOOLS_VERSION 57.5.0
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/0d8570dc44796f4369b652222cf176b3db6ac70e/public/get-pip.py
 ENV PYTHON_GET_PIP_SHA256 96461deced5c2a487ddc65207ec5a9cffeca0d34e7af7ea1afc470ff0d746207

--- a/3.8/alpine3.18/Dockerfile
+++ b/3.8/alpine3.18/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.16
+FROM alpine:3.18
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
@@ -20,8 +20,8 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
-ENV PYTHON_VERSION 3.10.11
+ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568
+ENV PYTHON_VERSION 3.8.16
 
 RUN set -eux; \
 	\
@@ -75,7 +75,6 @@ RUN set -eux; \
 		--enable-optimizations \
 		--enable-option-checking=fatal \
 		--enable-shared \
-		--with-lto \
 		--with-system-expat \
 		--without-ensurepip \
 	; \
@@ -107,6 +106,7 @@ RUN set -eux; \
 		\( \
 			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
 			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
+			-o \( -type f -a -name 'wininst-*.exe' \) \
 		\) -exec rm -rf '{}' + \
 	; \
 	\
@@ -130,9 +130,9 @@ RUN set -eux; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 23.0.1
+ENV PYTHON_PIP_VERSION 22.0.4
 # https://github.com/docker-library/python/issues/365
-ENV PYTHON_SETUPTOOLS_VERSION 65.5.1
+ENV PYTHON_SETUPTOOLS_VERSION 57.5.0
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/0d8570dc44796f4369b652222cf176b3db6ac70e/public/get-pip.py
 ENV PYTHON_GET_PIP_SHA256 96461deced5c2a487ddc65207ec5a9cffeca0d34e7af7ea1afc470ff0d746207

--- a/3.9/alpine3.18/Dockerfile
+++ b/3.9/alpine3.18/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.16
+FROM alpine:3.18
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
@@ -20,8 +20,8 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV GPG_KEY 7169605F62C751356D054A26A821E680E5FA6305
-ENV PYTHON_VERSION 3.12.0a7
+ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568
+ENV PYTHON_VERSION 3.9.16
 
 RUN set -eux; \
 	\
@@ -75,7 +75,6 @@ RUN set -eux; \
 		--enable-optimizations \
 		--enable-option-checking=fatal \
 		--enable-shared \
-		--with-lto \
 		--with-system-expat \
 		--without-ensurepip \
 	; \
@@ -130,9 +129,9 @@ RUN set -eux; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 23.0.1
+ENV PYTHON_PIP_VERSION 22.0.4
 # https://github.com/docker-library/python/issues/365
-ENV PYTHON_SETUPTOOLS_VERSION 65.5.1
+ENV PYTHON_SETUPTOOLS_VERSION 58.1.0
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/0d8570dc44796f4369b652222cf176b3db6ac70e/public/get-pip.py
 ENV PYTHON_GET_PIP_SHA256 96461deced5c2a487ddc65207ec5a9cffeca0d34e7af7ea1afc470ff0d746207

--- a/versions.json
+++ b/versions.json
@@ -13,8 +13,8 @@
       "slim-bullseye",
       "buster",
       "slim-buster",
+      "alpine3.18",
       "alpine3.17",
-      "alpine3.16",
       "windows/windowsservercore-ltsc2022",
       "windows/windowsservercore-1809"
     ],
@@ -34,8 +34,8 @@
       "slim-bullseye",
       "buster",
       "slim-buster",
+      "alpine3.18",
       "alpine3.17",
-      "alpine3.16",
       "windows/windowsservercore-ltsc2022",
       "windows/windowsservercore-1809"
     ],
@@ -55,8 +55,8 @@
       "slim-bullseye",
       "buster",
       "slim-buster",
+      "alpine3.18",
       "alpine3.17",
-      "alpine3.16",
       "windows/windowsservercore-ltsc2022",
       "windows/windowsservercore-1809"
     ],
@@ -76,8 +76,8 @@
       "slim-bullseye",
       "buster",
       "slim-buster",
-      "alpine3.17",
-      "alpine3.16"
+      "alpine3.18",
+      "alpine3.17"
     ],
     "version": "3.7.16"
   },
@@ -95,8 +95,8 @@
       "slim-bullseye",
       "buster",
       "slim-buster",
-      "alpine3.17",
-      "alpine3.16"
+      "alpine3.18",
+      "alpine3.17"
     ],
     "version": "3.8.16"
   },
@@ -114,8 +114,8 @@
       "slim-bullseye",
       "buster",
       "slim-buster",
-      "alpine3.17",
-      "alpine3.16"
+      "alpine3.18",
+      "alpine3.17"
     ],
     "version": "3.9.16"
   }

--- a/versions.sh
+++ b/versions.sh
@@ -172,8 +172,8 @@ for version in "${versions[@]}"; do
 					"buster"
 				| ., "slim-" + .), # https://github.com/docker-library/ruby/pull/142#issuecomment-320012893
 				(
-					"3.17",
-					"3.16"
+					"3.18",
+					"3.17"
 				| "alpine" + .),
 				if env.hasWindows != "" then
 					(


### PR DESCRIPTION
Also remove Alpine 3.16 variant

See also https://alpinelinux.org/posts/Alpine-3.18.0-released.html.