### PR TITLE
Enforce LF line-endings for all files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 /*/**/Dockerfile       linguist-generated
 /Dockerfile*.template  linguist-language=Dockerfile
+*                      text=auto eol=lf


### PR DESCRIPTION
* Required for getting the shebang right (for example, in WSL).
* Fixes jq failures on CRLF Dockerfiles:

```
jq: error: syntax error, unexpected INVALID_CHARACTER (Unix shell quoting issues?) at <top-level>, line 1:

jq: 1 compile error
```