### PR TITLE
Use latest pip & setuptools for python 3.9

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -101,10 +101,10 @@
     "pip": {
       "sha256": "96461deced5c2a487ddc65207ec5a9cffeca0d34e7af7ea1afc470ff0d746207",
       "url": "https://github.com/pypa/get-pip/raw/0d8570dc44796f4369b652222cf176b3db6ac70e/public/get-pip.py",
-      "version": "22.0.4"
+      "version": "23.1.2"
     },
     "setuptools": {
-      "version": "58.1.0"
+      "version": "67.8.0"
     },
     "variants": [
       "bullseye",


### PR DESCRIPTION
What's the reason for not using latest pip & setuptools?

Disclaimer: This PR only covers python 3.9 as I'm personally interested in this one only :)