### PR TITLE
Move "get-pip" URL to a separate versions.json section so commits are more clear

### DIFF
--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -311,8 +311,8 @@ ENV PYTHON_PIP_VERSION {{ .pip.version }}
 ENV PYTHON_SETUPTOOLS_VERSION {{ .setuptools.version }}
 {{ ) else "" end -}}
 # https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL {{ .pip.url }}
-ENV PYTHON_GET_PIP_SHA256 {{ .pip.sha256 }}
+ENV PYTHON_GET_PIP_URL {{ ."get-pip".url }}
+ENV PYTHON_GET_PIP_SHA256 {{ ."get-pip".sha256 }}
 
 RUN set -eux; \
 	\

--- a/Dockerfile-windows.template
+++ b/Dockerfile-windows.template
@@ -51,8 +51,8 @@ ENV PYTHON_PIP_VERSION {{ .pip.version }}
 ENV PYTHON_SETUPTOOLS_VERSION {{ .setuptools.version }}
 {{ ) else "" end -}}
 # https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL {{ .pip.url }}
-ENV PYTHON_GET_PIP_SHA256 {{ .pip.sha256 }}
+ENV PYTHON_GET_PIP_URL {{ ."get-pip".url }}
+ENV PYTHON_GET_PIP_SHA256 {{ ."get-pip".sha256 }}
 
 RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \

--- a/versions.json
+++ b/versions.json
@@ -1,8 +1,11 @@
 {
   "3.10": {
-    "pip": {
+    "get-pip": {
       "sha256": "221ebd8c2ac62fc2d6e80c60d9674e212c0a468879b7daddb0469570cfa5148f",
       "url": "https://github.com/pypa/get-pip/raw/12b30d8c229961b6c0892101b365ec185fab7e14/public/get-pip.py",
+      "version": "https://github.com/pypa/get-pip/commit/12b30d8c229961b6c0892101b365ec185fab7e14"
+    },
+    "pip": {
       "version": "23.0.1"
     },
     "setuptools": {
@@ -19,9 +22,12 @@
     "version": "3.10.12"
   },
   "3.11": {
-    "pip": {
+    "get-pip": {
       "sha256": "221ebd8c2ac62fc2d6e80c60d9674e212c0a468879b7daddb0469570cfa5148f",
       "url": "https://github.com/pypa/get-pip/raw/12b30d8c229961b6c0892101b365ec185fab7e14/public/get-pip.py",
+      "version": "https://github.com/pypa/get-pip/commit/12b30d8c229961b6c0892101b365ec185fab7e14"
+    },
+    "pip": {
       "version": "23.1.2"
     },
     "setuptools": {
@@ -40,9 +46,12 @@
     "version": "3.11.4"
   },
   "3.12-rc": {
-    "pip": {
+    "get-pip": {
       "sha256": "221ebd8c2ac62fc2d6e80c60d9674e212c0a468879b7daddb0469570cfa5148f",
       "url": "https://github.com/pypa/get-pip/raw/12b30d8c229961b6c0892101b365ec185fab7e14/public/get-pip.py",
+      "version": "https://github.com/pypa/get-pip/commit/12b30d8c229961b6c0892101b365ec185fab7e14"
+    },
+    "pip": {
       "version": "23.1.2"
     },
     "variants": [
@@ -58,9 +67,12 @@
     "version": "3.12.0b4"
   },
   "3.7": {
-    "pip": {
+    "get-pip": {
       "sha256": "221ebd8c2ac62fc2d6e80c60d9674e212c0a468879b7daddb0469570cfa5148f",
       "url": "https://github.com/pypa/get-pip/raw/12b30d8c229961b6c0892101b365ec185fab7e14/public/get-pip.py",
+      "version": "https://github.com/pypa/get-pip/commit/12b30d8c229961b6c0892101b365ec185fab7e14"
+    },
+    "pip": {
       "version": "23.0.1"
     },
     "setuptools": {
@@ -77,9 +89,12 @@
     "version": "3.7.17"
   },
   "3.8": {
-    "pip": {
+    "get-pip": {
       "sha256": "221ebd8c2ac62fc2d6e80c60d9674e212c0a468879b7daddb0469570cfa5148f",
       "url": "https://github.com/pypa/get-pip/raw/12b30d8c229961b6c0892101b365ec185fab7e14/public/get-pip.py",
+      "version": "https://github.com/pypa/get-pip/commit/12b30d8c229961b6c0892101b365ec185fab7e14"
+    },
+    "pip": {
       "version": "23.0.1"
     },
     "setuptools": {
@@ -96,9 +111,12 @@
     "version": "3.8.17"
   },
   "3.9": {
-    "pip": {
+    "get-pip": {
       "sha256": "221ebd8c2ac62fc2d6e80c60d9674e212c0a468879b7daddb0469570cfa5148f",
       "url": "https://github.com/pypa/get-pip/raw/12b30d8c229961b6c0892101b365ec185fab7e14/public/get-pip.py",
+      "version": "https://github.com/pypa/get-pip/commit/12b30d8c229961b6c0892101b365ec185fab7e14"
+    },
+    "pip": {
       "version": "23.0.1"
     },
     "setuptools": {

--- a/versions.sh
+++ b/versions.sh
@@ -21,7 +21,7 @@ getPipCommit="$(curl -fsSL 'https://github.com/pypa/get-pip/commits/main/public/
 getPipCommit="$(awk <<<"$getPipCommit" -F '[[:space:]]*[<>/]+' '$2 == "id" && $3 ~ /Commit/ { print $4; exit }')"
 getPipUrl="https://github.com/pypa/get-pip/raw/$getPipCommit/public/get-pip.py"
 getPipSha256="$(curl -fsSL "$getPipUrl" | sha256sum | cut -d' ' -f1)"
-export getPipUrl getPipSha256
+export getPipCommit getPipUrl getPipSha256
 
 has_linux_version() {
 	local dir="$1"; shift
@@ -179,6 +179,9 @@ for version in "${versions[@]}"; do
 			version: env.fullVersion,
 			pip: {
 				version: env.pipVersion,
+			},
+			"get-pip": {
+				version: "https://github.com/pypa/get-pip/commit/\(env.getPipCommit)",
 				url: env.getPipUrl,
 				sha256: env.getPipSha256,
 			},


### PR DESCRIPTION
This should help make commits like these more obvious at a glance (updating nothing but "get-pip"):

- https://github.com/docker-library/python/commit/4d12931: Update 3.9
- https://github.com/docker-library/python/commit/aaced40: Update 3.8
- https://github.com/docker-library/python/commit/597175b: Update 3.7
- https://github.com/docker-library/python/commit/b43fc27: Update 3.12-rc
- https://github.com/docker-library/python/commit/1af036f: Update 3.11
- https://github.com/docker-library/python/commit/00dce75: Update 3.10