### PR TITLE
Switch to multi-line GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,17 @@ name: GitHub CI
 on:
   pull_request:
   push:
+  workflow_dispatch:
   schedule:
     - cron: 0 0 * * 0
 
 defaults:
   run:
     shell: 'bash -Eeuo pipefail -x {0}'
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
 
@@ -41,8 +46,10 @@ jobs:
             )
           ')"
 
-          echo "strategy=$strategy" >> "$GITHUB_OUTPUT"
-          jq . <<<"$strategy" # sanity check / debugging aid
+          EOF="EOF-$RANDOM-$RANDOM-$RANDOM"
+          echo "strategy<<$EOF" >> "$GITHUB_OUTPUT"
+          jq <<<"$strategy" . | tee -a "$GITHUB_OUTPUT"
+          echo "$EOF" >> "$GITHUB_OUTPUT"
 
   test:
     needs: generate-jobs


### PR DESCRIPTION
GitHub's being weird about our single-line GITHUB_OUTPUT now, so let's switch to multi-line (which also lets us have a prettier multi-line value, so why not)

---

We're getting this in multiple places:

> ```console
> Error: Unable to process file command 'output' successfully.
> Error: Invalid format 'strategy={"fail-fast":false,"matrix":{"include":[{"name":"3.12.0b4-bookworm","os":"ubuntu-latest","meta":{"entries":[{"name":"3.12.0b4-bookworm","tags":["python:3.12.0b4-bookworm","python:3.12-rc-bookworm","python:3.12.0b4","python:3.12-rc"],"directory":"3.12-rc/bookworm","file":"Dockerfile","builder":"buildkit","constraints":[],"froms":["buildpack-deps:bookworm"]}],"froms":["buildpack-deps:bookworm"],"dockerfiles":["3.12-rc/bookworm/Dockerfile"]},"runs":{"build":"docker buildx build --progress plain --build-arg BUILDKIT_SYNTAX=\"$BASHBREW_BUILDKIT_SYNTAX\" --tag 'python:3.12.0b4-bookworm' --tag 'python:3.12-rc-bookworm' --tag 'python:3.12.0b4' --tag 'python:3.12-rc' '3.12-rc/bookworm'","history":"docker history 'python:3.12.0b4-bookworm'","test":"set -- 'python:3.12.0b4-bookworm'\nif [ -s ./.test/config.sh ]; then set -- --config ~/oi/test/config.sh --config ./.test/config.sh \"$@\"; fi\n~/oi/test/run.sh \"$@\"\naFiles=\"$(docker run --rm 'python:3.12.0b4-bookworm' find /usr/local -name \"*.a\" | tee /dev/stderr)\"; [ -z \"$aFiles\" ]","prepare":"git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# [https://github.com/docker-library/bashbrew/pull/43\nif](https://github.com/docker-library/bashbrew/pull/43/nif) [ -x ~/oi/.bin/bashbrew-buildkit-env-setup.sh ]; then\n\t# [https://github.com/docker-library/official-images/pull/14212\n\tbuildkitEnvs=\](https://github.com/docker-library/official-images/pull/14212/n/tbuildkitEnvs=/)"$(~/oi/.bin/bashbrew-buildkit-env-setup.sh)\"\n\tjq <<<\"$buildkitEnvs\" -r '\n\t\t\tto_entries | map(\n\t\t\t\t(.key | if test(\"[^a-zA-Z0-9_]+\") then\n\t\t\t\t\terror(\"invalid env key: \\(.)\")\n\t\t\t\telse . end)\n\t\t\t\t+ \"=\"\n\t\t\t\t+ (.value | if test(\"[\\r\\n]+\") then\n\t\t\t\t\terror(\"invalid env value: \\(.)\")\n\t\t\t\telse . end)\n\t\t\t) | join(\"\\n\")\n\t\t' | tee -a \"$GITHUB_ENV\"\nelse\n\tBASHBREW_BUILDKIT_SYNTAX=\"$(< ~/oi/.bashbrew-buildkit-syntax)\"; export BASHBREW_BUILDKIT_SYNTAX\n\tprintf \"BASHBREW_BUILDKIT_SYNTAX=%q\\n\" \"$BASHBREW_BUILDKIT_SYNTAX\" >> \"$GITHUB_ENV\"\nfi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -","pull":"docker pull 'buildpack-deps:bookworm'","images":"docker image ls --filter since=image-list-marker"}},{"name":"3.12.0b4-slim-bookworm","os":"ubuntu-latest","meta":{"entries":[{"name":"3.12.0b4-slim-bookworm","tags":["python:3.12.0b4-slim-bookworm","python:3.12-rc-slim-bookworm","python:3.12.0b4-slim","python:3.12-rc-slim"],"directory":"3.12-rc/slim-bookworm","file":"Dockerfile","builder":"buildkit","constraints":[],"froms":["debian:bookworm-slim"]}],"froms":["debian:bookworm-slim"],"dockerfiles":["3.12-rc/slim-bookworm/Dockerfile"]},"runs":{"build":"docker buildx build --progress plain --build-arg BUILDKIT_SYNTAX=\"$BASHBREW_BUILDKIT_SYNTAX\" --tag 'python:3.12.0b4-slim-bookworm' --tag 'python:3.12-rc-slim-bookworm' --tag 'python:3.12.0b4-slim' --tag 'python:3.12-rc-slim' '3.12-rc/slim-bookworm'","history":"docker history 'python:3.12.0b4-slim-bookworm'","test":"set -- 'python:3.12.0b4-slim-bookworm'\nif [ -s ./.test/config.sh ]; then set -- --config ~/oi/test/config.sh --config ./.test/config.sh \"$@\"; fi\n~/oi/test/run.sh \"$@\"\naFiles=\"$(docker run --rm 'python:3.12.0b4-slim-bookworm' find /usr/local -name \"*.a\" | tee /dev/stderr)\"; [ -z \"$aFiles\" ]","prepare":"git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# [https://github.com/docker-library/bashbrew/pull/43\nif](https://github.com/docker-library/bashbrew/pull/43/nif) [ -x ~/oi/.bin/bashbrew-buildkit-env-setup.sh ]; then\n\t# [https://github.com/docker-library/official-images/pull/14212\n\tbuildkitEnvs=\](https://github.com/docker-library/official-images/pull/14212/n/tbuildkitEnvs=/)"$(~/oi/.bin/bashbrew-buildkit-env-setup.sh)\"\n\tjq <<<\"$buildkitEnvs\" -r '\n\t\t\tto_entries | map(\n\t\t\t\t(.key | if test(\"[^a-zA-Z0-9_]+\") then\n\t\t\t\t\terror(\"invalid env key: \\(.)\")\n\t\t\t\telse . end)\n\t\t\t\t+ \"=\"\n\t\t\t\t+ (.value | if test(\"[\\r\\n]+\") then\n\t\t\t\t\terror(\"invalid env value: \\(.)\")\n\t\t\t\telse . end)\n\t\t\t) | join(\"\\n\")\n\t\t' | tee -a \"$GITHUB_ENV\"\nelse\n\tBASHBREW_BUILDKIT_S
> ```