### PR TITLE
add symlinks in /usr/bin

### DIFF
--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -256,6 +256,7 @@ RUN set -eux; \
 		[ -s "/usr/local/bin/$src" ]; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
 		ln -svT "$src" "/usr/local/bin/$dst"; \
+		ln -svT "/usr/local/bin/$src" "/usr/bin/$dst"; \
 	done
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"


### PR DESCRIPTION
Using the stock python:slim container is really difficult if you already have an existing script with `#!/usr/bin/python3` on top. You will get a confusing error like:

```
/usr/bin/bash: line 140: ./check.py: cannot execute: required file not found
```

... while the script otherwise works perfectly well. I understand that it's relatively standard to install things in `/usr/local` and I generally support this, but in this very specific case, it seems extremely backwards.

I also understand that, normally, you should *install* a script with an `entrypoint` and so on, but we shouldn't let perfection be the enemy of good here.