### PR TITLE
Attempt to speed up riscv64 builds

### DIFF
--- a/3.10/alpine3.19/Dockerfile
+++ b/3.10/alpine3.19/Dockerfile
@@ -73,7 +73,7 @@ RUN set -eux; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
-		--enable-optimizations \
+		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--enable-optimizations') \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-lto \

--- a/3.10/alpine3.20/Dockerfile
+++ b/3.10/alpine3.20/Dockerfile
@@ -73,7 +73,7 @@ RUN set -eux; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
-		--enable-optimizations \
+		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--enable-optimizations') \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-lto \

--- a/3.11/alpine3.19/Dockerfile
+++ b/3.11/alpine3.19/Dockerfile
@@ -73,7 +73,7 @@ RUN set -eux; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
-		--enable-optimizations \
+		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--enable-optimizations') \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-lto \

--- a/3.11/alpine3.20/Dockerfile
+++ b/3.11/alpine3.20/Dockerfile
@@ -73,7 +73,7 @@ RUN set -eux; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
-		--enable-optimizations \
+		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--enable-optimizations') \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-lto \

--- a/3.12/alpine3.19/Dockerfile
+++ b/3.12/alpine3.19/Dockerfile
@@ -73,7 +73,7 @@ RUN set -eux; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
-		--enable-optimizations \
+		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--enable-optimizations') \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-lto \

--- a/3.12/alpine3.20/Dockerfile
+++ b/3.12/alpine3.20/Dockerfile
@@ -73,7 +73,7 @@ RUN set -eux; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
-		--enable-optimizations \
+		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--enable-optimizations') \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-lto \

--- a/3.13-rc/alpine3.19/Dockerfile
+++ b/3.13-rc/alpine3.19/Dockerfile
@@ -68,7 +68,7 @@ RUN set -eux; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
-		--enable-optimizations \
+		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--enable-optimizations') \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-lto \

--- a/3.13-rc/alpine3.20/Dockerfile
+++ b/3.13-rc/alpine3.20/Dockerfile
@@ -68,7 +68,7 @@ RUN set -eux; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
-		--enable-optimizations \
+		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--enable-optimizations') \
 		--enable-option-checking=fatal \
 		--enable-shared \
 		--with-lto \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -158,7 +158,15 @@ RUN set -eux; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
+{{
+	# skip optimizations on alpine on riscv64 (except python 3.8 and 3.9)
+	# only 3.8 and 3.9 complete building on riscv64 with optimizations, 3.10-3.13rc all hit the 3 hour limit
+	if (is_alpine | not) or ( [ "3.8", "3.9" ] | index(rcVersion) ) then (
+-}}
 		--enable-optimizations \
+{{ ) else ( -}}
+		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--enable-optimizations') \
+{{ ) end -}}
 		--enable-option-checking=fatal \
 		--enable-shared \
 {{


### PR DESCRIPTION
Some Python riscv64 images currently fail to complete building and hit the 3-hour Jenkins job limit. 

Currently that is `python:3.13.0b2-alpine3.20`, `python:3.12.4-alpine3.20`, `python:3.11.9-alpine3.20`, `python:3.10.14-alpine3.20`

This change is an attempt to get them to build in the allotted time instead of just dropping `riscv64` on these Python versions. A less optimized python is better than no python image at all.

Build speed when emulating `riscv64` from `amd64` WSL (~14 cores, so a bit more than our `riscv64` builder):
| python  | with optimizations |    without |
|---------|-------------------:|-----------:|
| 3.9     |         15 minutes |         \- |
| 3.10    |         52 minutes | 23 minutes |
| 3.11    |         92 minutes | 47 minutes |
| 3.12    |        103 minutes | 50 minutes |
| 3.13-rc |        109 minutes |    not tested|