### PR TITLE
Remove riscv64 from python versions that are too slow to build

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -137,6 +137,10 @@ for version; do
 		case "$version" in
 			3.8 | 3.9) ;;
 			*)
+				if [ "$version" != '3.10' ]; then
+					# https://github.com/docker-library/python/pull/931
+					variantArches="$(sed <<<" $variantArches " -e 's/ riscv64 / /g')"
+				fi
 				# https://github.com/python/cpython/issues/93619 + https://peps.python.org/pep-0011/
 				variantArches="$(sed <<<" $variantArches " -e 's/ mips64le / /g')"
 				;;


### PR DESCRIPTION
https://github.com/docker-library/python/pull/931 was enough for Python `3.10` 🎉, but not `3.11`, `3.12`, or `3.13-rc` 😞😢. They still take more than 3 hours to build. 😱

Not sure if there is a way to bring them back. 🤔 `riscv64` is not a supported platform (https://peps.python.org/pep-0011/) and I doubt the compile time of Python itself is a goal of the project (or of `gcc`).

![image](https://github.com/docker-library/python/assets/896423/2d81fc79-794a-4652-8d66-f367e81ab8f6)
