### PR TITLE
Stop installing setuptools in python 3.12+

### DIFF
--- a/3.10/alpine3.19/Dockerfile
+++ b/3.10/alpine3.19/Dockerfile
@@ -151,6 +151,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.10/alpine3.20/Dockerfile
+++ b/3.10/alpine3.20/Dockerfile
@@ -151,6 +151,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.10/bookworm/Dockerfile
+++ b/3.10/bookworm/Dockerfile
@@ -121,6 +121,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.10/bullseye/Dockerfile
+++ b/3.10/bullseye/Dockerfile
@@ -121,6 +121,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.10/slim-bookworm/Dockerfile
+++ b/3.10/slim-bookworm/Dockerfile
@@ -164,6 +164,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.10/slim-bullseye/Dockerfile
+++ b/3.10/slim-bullseye/Dockerfile
@@ -164,6 +164,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.11/alpine3.19/Dockerfile
+++ b/3.11/alpine3.19/Dockerfile
@@ -151,6 +151,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.11/alpine3.20/Dockerfile
+++ b/3.11/alpine3.20/Dockerfile
@@ -151,6 +151,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.11/bookworm/Dockerfile
+++ b/3.11/bookworm/Dockerfile
@@ -121,6 +121,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.11/bullseye/Dockerfile
+++ b/3.11/bullseye/Dockerfile
@@ -121,6 +121,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.11/slim-bookworm/Dockerfile
+++ b/3.11/slim-bookworm/Dockerfile
@@ -164,6 +164,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.11/slim-bullseye/Dockerfile
+++ b/3.11/slim-bullseye/Dockerfile
@@ -164,6 +164,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.11/windows/windowsservercore-1809/Dockerfile
+++ b/3.11/windows/windowsservercore-1809/Dockerfile
@@ -76,6 +76,8 @@ RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); 
 		--no-compile \
 		('pip=={0}' -f $env:PYTHON_PIP_VERSION) \
 		('setuptools=={0}' -f $env:PYTHON_SETUPTOOLS_VERSION) \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	Remove-Item get-pip.py -Force; \
 	\

--- a/3.11/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/3.11/windows/windowsservercore-ltsc2022/Dockerfile
@@ -76,6 +76,8 @@ RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); 
 		--no-compile \
 		('pip=={0}' -f $env:PYTHON_PIP_VERSION) \
 		('setuptools=={0}' -f $env:PYTHON_SETUPTOOLS_VERSION) \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	Remove-Item get-pip.py -Force; \
 	\

--- a/3.12/alpine3.19/Dockerfile
+++ b/3.12/alpine3.19/Dockerfile
@@ -148,6 +148,8 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
+		--no-setuptools \
+		--no-wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.12/alpine3.20/Dockerfile
+++ b/3.12/alpine3.20/Dockerfile
@@ -148,6 +148,8 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
+		--no-setuptools \
+		--no-wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.12/bookworm/Dockerfile
+++ b/3.12/bookworm/Dockerfile
@@ -118,6 +118,8 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
+		--no-setuptools \
+		--no-wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.12/bullseye/Dockerfile
+++ b/3.12/bullseye/Dockerfile
@@ -118,6 +118,8 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
+		--no-setuptools \
+		--no-wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.12/slim-bookworm/Dockerfile
+++ b/3.12/slim-bookworm/Dockerfile
@@ -161,6 +161,8 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
+		--no-setuptools \
+		--no-wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.12/slim-bullseye/Dockerfile
+++ b/3.12/slim-bullseye/Dockerfile
@@ -161,6 +161,8 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
+		--no-setuptools \
+		--no-wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.12/windows/windowsservercore-1809/Dockerfile
+++ b/3.12/windows/windowsservercore-1809/Dockerfile
@@ -73,6 +73,8 @@ RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); 
 		--no-cache-dir \
 		--no-compile \
 		('pip=={0}' -f $env:PYTHON_PIP_VERSION) \
+		--no-setuptools \
+		--no-wheel \
 	; \
 	Remove-Item get-pip.py -Force; \
 	\

--- a/3.12/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/3.12/windows/windowsservercore-ltsc2022/Dockerfile
@@ -73,6 +73,8 @@ RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); 
 		--no-cache-dir \
 		--no-compile \
 		('pip=={0}' -f $env:PYTHON_PIP_VERSION) \
+		--no-setuptools \
+		--no-wheel \
 	; \
 	Remove-Item get-pip.py -Force; \
 	\

--- a/3.13-rc/alpine3.19/Dockerfile
+++ b/3.13-rc/alpine3.19/Dockerfile
@@ -143,6 +143,8 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
+		--no-setuptools \
+		--no-wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.13-rc/alpine3.20/Dockerfile
+++ b/3.13-rc/alpine3.20/Dockerfile
@@ -143,6 +143,8 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
+		--no-setuptools \
+		--no-wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.13-rc/bookworm/Dockerfile
+++ b/3.13-rc/bookworm/Dockerfile
@@ -113,6 +113,8 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
+		--no-setuptools \
+		--no-wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.13-rc/bullseye/Dockerfile
+++ b/3.13-rc/bullseye/Dockerfile
@@ -113,6 +113,8 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
+		--no-setuptools \
+		--no-wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.13-rc/slim-bookworm/Dockerfile
+++ b/3.13-rc/slim-bookworm/Dockerfile
@@ -156,6 +156,8 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
+		--no-setuptools \
+		--no-wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.13-rc/slim-bullseye/Dockerfile
+++ b/3.13-rc/slim-bullseye/Dockerfile
@@ -156,6 +156,8 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
+		--no-setuptools \
+		--no-wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.13-rc/windows/windowsservercore-1809/Dockerfile
+++ b/3.13-rc/windows/windowsservercore-1809/Dockerfile
@@ -73,6 +73,8 @@ RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); 
 		--no-cache-dir \
 		--no-compile \
 		('pip=={0}' -f $env:PYTHON_PIP_VERSION) \
+		--no-setuptools \
+		--no-wheel \
 	; \
 	Remove-Item get-pip.py -Force; \
 	\

--- a/3.13-rc/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/3.13-rc/windows/windowsservercore-ltsc2022/Dockerfile
@@ -73,6 +73,8 @@ RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); 
 		--no-cache-dir \
 		--no-compile \
 		('pip=={0}' -f $env:PYTHON_PIP_VERSION) \
+		--no-setuptools \
+		--no-wheel \
 	; \
 	Remove-Item get-pip.py -Force; \
 	\

--- a/3.8/alpine3.19/Dockerfile
+++ b/3.8/alpine3.19/Dockerfile
@@ -151,6 +151,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.8/alpine3.20/Dockerfile
+++ b/3.8/alpine3.20/Dockerfile
@@ -151,6 +151,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.8/bookworm/Dockerfile
+++ b/3.8/bookworm/Dockerfile
@@ -121,6 +121,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.8/bullseye/Dockerfile
+++ b/3.8/bullseye/Dockerfile
@@ -121,6 +121,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.8/slim-bookworm/Dockerfile
+++ b/3.8/slim-bookworm/Dockerfile
@@ -164,6 +164,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.8/slim-bullseye/Dockerfile
+++ b/3.8/slim-bullseye/Dockerfile
@@ -164,6 +164,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.9/alpine3.19/Dockerfile
+++ b/3.9/alpine3.19/Dockerfile
@@ -150,6 +150,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.9/alpine3.20/Dockerfile
+++ b/3.9/alpine3.20/Dockerfile
@@ -150,6 +150,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.9/bookworm/Dockerfile
+++ b/3.9/bookworm/Dockerfile
@@ -120,6 +120,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.9/bullseye/Dockerfile
+++ b/3.9/bullseye/Dockerfile
@@ -120,6 +120,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.9/slim-bookworm/Dockerfile
+++ b/3.9/slim-bookworm/Dockerfile
@@ -163,6 +163,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/3.9/slim-bullseye/Dockerfile
+++ b/3.9/slim-bullseye/Dockerfile
@@ -163,6 +163,8 @@ RUN set -eux; \
 		--no-compile \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
 	; \
 	rm -f get-pip.py; \
 	\

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -307,7 +307,12 @@ RUN set -eux; \
 		"pip==$PYTHON_PIP_VERSION" \
 {{ if .setuptools then ( -}}
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
-{{ ) else "" end -}}
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
+{{ ) else ( -}}
+		--no-setuptools \
+		--no-wheel \
+{{ ) end -}}
 	; \
 	rm -f get-pip.py; \
 	\

--- a/Dockerfile-windows.template
+++ b/Dockerfile-windows.template
@@ -73,7 +73,12 @@ RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); 
 		('pip=={0}' -f $env:PYTHON_PIP_VERSION) \
 {{ if .setuptools then ( -}}
 		('setuptools=={0}' -f $env:PYTHON_SETUPTOOLS_VERSION) \
-{{ ) else "" end -}}
+		# get-pip.py installs wheel by default, adding in case get-pip defaults change
+		wheel \
+{{ ) else ( -}}
+		--no-setuptools \
+		--no-wheel \
+{{ ) end -}}
 	; \
 	Remove-Item get-pip.py -Force; \
 	\


### PR DESCRIPTION
This fixes the intent that was meant to happen in #833 of no longer including setuptools (or wheel).

Fixes #952.

If you are using Python 3.12+ and you have build or runtime dependencies on setuptools or wheel, a simple addition to your Dockerfile is all that is needed. (I think longer term, they might make sense as additions to your `requirements.txt`)
```dockerfile
FROM python:3.12
WORKDIR /usr/src/app

### ⬇️ this line ⬇️ ##########################
RUN pip install --no-cache-dir setuptools wheel
###############################################

# continue your regular installation
COPY requirements.txt ./
RUN pip install --no-cache-dir -r requirements.txt

# ...
```