### PR TITLE
Draft implementation of sigstore for alpine images

### DIFF
--- a/3.10/alpine3.19/Dockerfile
+++ b/3.10/alpine3.19/Dockerfile
@@ -21,14 +21,15 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
+ENV CERTIFICATE_ISSUER https://accounts.google.com
+ENV CERTIFICATE_IDENTITY pablogsal@python.org
 ENV PYTHON_VERSION 3.10.15
 ENV PYTHON_SHA256 aab0950817735172601879872d937c1e4928a57c409ae02369ec3d91dccebe79
 
 RUN set -eux; \
 	\
+	apk add --no-cache --virtual .cosign cosign --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community; \
 	apk add --no-cache --virtual .build-deps \
-		gnupg \
 		tar \
 		xz \
 		\
@@ -60,12 +61,9 @@ RUN set -eux; \
 	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	echo "$PYTHON_SHA256 *python.tar.xz" | sha256sum -c -; \
-	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
-	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY"; \
-	gpg --batch --verify python.tar.xz.asc python.tar.xz; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" python.tar.xz.asc; \
+	wget -O python.tar.xz.sigstore "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.sigstore"; \
+	cosign verify-blob python.tar.xz --bundle python.tar.xz.sigstore --new-bundle-format \
+		--certificate-identity ${CERTIFICATE_IDENTITY} --certificate-oidc-issuer ${CERTIFICATE_ISSUER}; \
 	mkdir -p /usr/src/python; \
 	tar --extract --directory /usr/src/python --strip-components=1 --file python.tar.xz; \
 	rm python.tar.xz; \
@@ -119,6 +117,7 @@ RUN set -eux; \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 		| xargs -rt apk add --no-network --virtual .python-rundeps \
 	; \
+	apk del --no-network .cosign; \
 	apk del --no-network .build-deps; \
 	\
 	export PYTHONDONTWRITEBYTECODE=1; \

--- a/3.10/alpine3.20/Dockerfile
+++ b/3.10/alpine3.20/Dockerfile
@@ -21,14 +21,15 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
+ENV CERTIFICATE_ISSUER https://accounts.google.com
+ENV CERTIFICATE_IDENTITY pablogsal@python.org
 ENV PYTHON_VERSION 3.10.15
 ENV PYTHON_SHA256 aab0950817735172601879872d937c1e4928a57c409ae02369ec3d91dccebe79
 
 RUN set -eux; \
 	\
+	apk add --no-cache --virtual .cosign cosign --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community; \
 	apk add --no-cache --virtual .build-deps \
-		gnupg \
 		tar \
 		xz \
 		\
@@ -60,12 +61,9 @@ RUN set -eux; \
 	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	echo "$PYTHON_SHA256 *python.tar.xz" | sha256sum -c -; \
-	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
-	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY"; \
-	gpg --batch --verify python.tar.xz.asc python.tar.xz; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" python.tar.xz.asc; \
+	wget -O python.tar.xz.sigstore "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.sigstore"; \
+	cosign verify-blob python.tar.xz --bundle python.tar.xz.sigstore --new-bundle-format \
+		--certificate-identity ${CERTIFICATE_IDENTITY} --certificate-oidc-issuer ${CERTIFICATE_ISSUER}; \
 	mkdir -p /usr/src/python; \
 	tar --extract --directory /usr/src/python --strip-components=1 --file python.tar.xz; \
 	rm python.tar.xz; \
@@ -119,6 +117,7 @@ RUN set -eux; \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 		| xargs -rt apk add --no-network --virtual .python-rundeps \
 	; \
+	apk del --no-network .cosign; \
 	apk del --no-network .build-deps; \
 	\
 	export PYTHONDONTWRITEBYTECODE=1; \

--- a/3.11/alpine3.19/Dockerfile
+++ b/3.11/alpine3.19/Dockerfile
@@ -21,14 +21,15 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
+ENV CERTIFICATE_ISSUER https://accounts.google.com
+ENV CERTIFICATE_IDENTITY pablogsal@python.org
 ENV PYTHON_VERSION 3.11.10
 ENV PYTHON_SHA256 07a4356e912900e61a15cb0949a06c4a05012e213ecd6b4e84d0f67aabbee372
 
 RUN set -eux; \
 	\
+	apk add --no-cache --virtual .cosign cosign --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community; \
 	apk add --no-cache --virtual .build-deps \
-		gnupg \
 		tar \
 		xz \
 		\
@@ -60,12 +61,9 @@ RUN set -eux; \
 	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	echo "$PYTHON_SHA256 *python.tar.xz" | sha256sum -c -; \
-	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
-	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY"; \
-	gpg --batch --verify python.tar.xz.asc python.tar.xz; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" python.tar.xz.asc; \
+	wget -O python.tar.xz.sigstore "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.sigstore"; \
+	cosign verify-blob python.tar.xz --bundle python.tar.xz.sigstore --new-bundle-format \
+		--certificate-identity ${CERTIFICATE_IDENTITY} --certificate-oidc-issuer ${CERTIFICATE_ISSUER}; \
 	mkdir -p /usr/src/python; \
 	tar --extract --directory /usr/src/python --strip-components=1 --file python.tar.xz; \
 	rm python.tar.xz; \
@@ -119,6 +117,7 @@ RUN set -eux; \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 		| xargs -rt apk add --no-network --virtual .python-rundeps \
 	; \
+	apk del --no-network .cosign; \
 	apk del --no-network .build-deps; \
 	\
 	export PYTHONDONTWRITEBYTECODE=1; \

--- a/3.11/alpine3.20/Dockerfile
+++ b/3.11/alpine3.20/Dockerfile
@@ -21,14 +21,15 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
+ENV CERTIFICATE_ISSUER https://accounts.google.com
+ENV CERTIFICATE_IDENTITY pablogsal@python.org
 ENV PYTHON_VERSION 3.11.10
 ENV PYTHON_SHA256 07a4356e912900e61a15cb0949a06c4a05012e213ecd6b4e84d0f67aabbee372
 
 RUN set -eux; \
 	\
+	apk add --no-cache --virtual .cosign cosign --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community; \
 	apk add --no-cache --virtual .build-deps \
-		gnupg \
 		tar \
 		xz \
 		\
@@ -60,12 +61,9 @@ RUN set -eux; \
 	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	echo "$PYTHON_SHA256 *python.tar.xz" | sha256sum -c -; \
-	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
-	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY"; \
-	gpg --batch --verify python.tar.xz.asc python.tar.xz; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" python.tar.xz.asc; \
+	wget -O python.tar.xz.sigstore "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.sigstore"; \
+	cosign verify-blob python.tar.xz --bundle python.tar.xz.sigstore --new-bundle-format \
+		--certificate-identity ${CERTIFICATE_IDENTITY} --certificate-oidc-issuer ${CERTIFICATE_ISSUER}; \
 	mkdir -p /usr/src/python; \
 	tar --extract --directory /usr/src/python --strip-components=1 --file python.tar.xz; \
 	rm python.tar.xz; \
@@ -119,6 +117,7 @@ RUN set -eux; \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 		| xargs -rt apk add --no-network --virtual .python-rundeps \
 	; \
+	apk del --no-network .cosign; \
 	apk del --no-network .build-deps; \
 	\
 	export PYTHONDONTWRITEBYTECODE=1; \

--- a/3.12/alpine3.19/Dockerfile
+++ b/3.12/alpine3.19/Dockerfile
@@ -21,14 +21,15 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV GPG_KEY 7169605F62C751356D054A26A821E680E5FA6305
+ENV CERTIFICATE_ISSUER https://accounts.google.com
+ENV CERTIFICATE_IDENTITY thomas@python.org
 ENV PYTHON_VERSION 3.12.7
 ENV PYTHON_SHA256 24887b92e2afd4a2ac602419ad4b596372f67ac9b077190f459aba390faf5550
 
 RUN set -eux; \
 	\
+	apk add --no-cache --virtual .cosign cosign --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community; \
 	apk add --no-cache --virtual .build-deps \
-		gnupg \
 		tar \
 		xz \
 		\
@@ -60,12 +61,9 @@ RUN set -eux; \
 	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	echo "$PYTHON_SHA256 *python.tar.xz" | sha256sum -c -; \
-	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
-	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY"; \
-	gpg --batch --verify python.tar.xz.asc python.tar.xz; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" python.tar.xz.asc; \
+	wget -O python.tar.xz.sigstore "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.sigstore"; \
+	cosign verify-blob python.tar.xz --bundle python.tar.xz.sigstore --new-bundle-format \
+		--certificate-identity ${CERTIFICATE_IDENTITY} --certificate-oidc-issuer ${CERTIFICATE_ISSUER}; \
 	mkdir -p /usr/src/python; \
 	tar --extract --directory /usr/src/python --strip-components=1 --file python.tar.xz; \
 	rm python.tar.xz; \
@@ -119,6 +117,7 @@ RUN set -eux; \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 		| xargs -rt apk add --no-network --virtual .python-rundeps \
 	; \
+	apk del --no-network .cosign; \
 	apk del --no-network .build-deps; \
 	\
 	export PYTHONDONTWRITEBYTECODE=1; \

--- a/3.12/alpine3.20/Dockerfile
+++ b/3.12/alpine3.20/Dockerfile
@@ -21,14 +21,15 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV GPG_KEY 7169605F62C751356D054A26A821E680E5FA6305
+ENV CERTIFICATE_ISSUER https://accounts.google.com
+ENV CERTIFICATE_IDENTITY thomas@python.org
 ENV PYTHON_VERSION 3.12.7
 ENV PYTHON_SHA256 24887b92e2afd4a2ac602419ad4b596372f67ac9b077190f459aba390faf5550
 
 RUN set -eux; \
 	\
+	apk add --no-cache --virtual .cosign cosign --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community; \
 	apk add --no-cache --virtual .build-deps \
-		gnupg \
 		tar \
 		xz \
 		\
@@ -60,12 +61,9 @@ RUN set -eux; \
 	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	echo "$PYTHON_SHA256 *python.tar.xz" | sha256sum -c -; \
-	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
-	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY"; \
-	gpg --batch --verify python.tar.xz.asc python.tar.xz; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" python.tar.xz.asc; \
+	wget -O python.tar.xz.sigstore "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.sigstore"; \
+	cosign verify-blob python.tar.xz --bundle python.tar.xz.sigstore --new-bundle-format \
+		--certificate-identity ${CERTIFICATE_IDENTITY} --certificate-oidc-issuer ${CERTIFICATE_ISSUER}; \
 	mkdir -p /usr/src/python; \
 	tar --extract --directory /usr/src/python --strip-components=1 --file python.tar.xz; \
 	rm python.tar.xz; \
@@ -119,6 +117,7 @@ RUN set -eux; \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 		| xargs -rt apk add --no-network --virtual .python-rundeps \
 	; \
+	apk del --no-network .cosign; \
 	apk del --no-network .build-deps; \
 	\
 	export PYTHONDONTWRITEBYTECODE=1; \

--- a/3.13/alpine3.19/Dockerfile
+++ b/3.13/alpine3.19/Dockerfile
@@ -16,14 +16,15 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV GPG_KEY 7169605F62C751356D054A26A821E680E5FA6305
+ENV CERTIFICATE_ISSUER https://accounts.google.com
+ENV CERTIFICATE_IDENTITY thomas@python.org
 ENV PYTHON_VERSION 3.13.0
 ENV PYTHON_SHA256 086de5882e3cb310d4dca48457522e2e48018ecd43da9cdf827f6a0759efb07d
 
 RUN set -eux; \
 	\
+	apk add --no-cache --virtual .cosign cosign --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community; \
 	apk add --no-cache --virtual .build-deps \
-		gnupg \
 		tar \
 		xz \
 		\
@@ -55,12 +56,9 @@ RUN set -eux; \
 	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	echo "$PYTHON_SHA256 *python.tar.xz" | sha256sum -c -; \
-	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
-	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY"; \
-	gpg --batch --verify python.tar.xz.asc python.tar.xz; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" python.tar.xz.asc; \
+	wget -O python.tar.xz.sigstore "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.sigstore"; \
+	cosign verify-blob python.tar.xz --bundle python.tar.xz.sigstore --new-bundle-format \
+		--certificate-identity ${CERTIFICATE_IDENTITY} --certificate-oidc-issuer ${CERTIFICATE_ISSUER}; \
 	mkdir -p /usr/src/python; \
 	tar --extract --directory /usr/src/python --strip-components=1 --file python.tar.xz; \
 	rm python.tar.xz; \
@@ -114,6 +112,7 @@ RUN set -eux; \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 		| xargs -rt apk add --no-network --virtual .python-rundeps \
 	; \
+	apk del --no-network .cosign; \
 	apk del --no-network .build-deps; \
 	\
 	export PYTHONDONTWRITEBYTECODE=1; \

--- a/3.13/alpine3.20/Dockerfile
+++ b/3.13/alpine3.20/Dockerfile
@@ -16,14 +16,15 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV GPG_KEY 7169605F62C751356D054A26A821E680E5FA6305
+ENV CERTIFICATE_ISSUER https://accounts.google.com
+ENV CERTIFICATE_IDENTITY thomas@python.org
 ENV PYTHON_VERSION 3.13.0
 ENV PYTHON_SHA256 086de5882e3cb310d4dca48457522e2e48018ecd43da9cdf827f6a0759efb07d
 
 RUN set -eux; \
 	\
+	apk add --no-cache --virtual .cosign cosign --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community; \
 	apk add --no-cache --virtual .build-deps \
-		gnupg \
 		tar \
 		xz \
 		\
@@ -55,12 +56,9 @@ RUN set -eux; \
 	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	echo "$PYTHON_SHA256 *python.tar.xz" | sha256sum -c -; \
-	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
-	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY"; \
-	gpg --batch --verify python.tar.xz.asc python.tar.xz; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" python.tar.xz.asc; \
+	wget -O python.tar.xz.sigstore "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.sigstore"; \
+	cosign verify-blob python.tar.xz --bundle python.tar.xz.sigstore --new-bundle-format \
+		--certificate-identity ${CERTIFICATE_IDENTITY} --certificate-oidc-issuer ${CERTIFICATE_ISSUER}; \
 	mkdir -p /usr/src/python; \
 	tar --extract --directory /usr/src/python --strip-components=1 --file python.tar.xz; \
 	rm python.tar.xz; \
@@ -114,6 +112,7 @@ RUN set -eux; \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 		| xargs -rt apk add --no-network --virtual .python-rundeps \
 	; \
+	apk del --no-network .cosign; \
 	apk del --no-network .build-deps; \
 	\
 	export PYTHONDONTWRITEBYTECODE=1; \

--- a/3.14-rc/alpine3.19/Dockerfile
+++ b/3.14-rc/alpine3.19/Dockerfile
@@ -16,13 +16,15 @@ RUN set -eux; \
 		tzdata \
 	;
 
+ENV CERTIFICATE_ISSUER https://github.com/login/oauth
+ENV CERTIFICATE_IDENTITY hugo@python.org
 ENV PYTHON_VERSION 3.14.0a1
 ENV PYTHON_SHA256 3e464b0cbb7535e2db34262fd19a0a393d0e62be0f43b1513ed98379b054ead4
 
 RUN set -eux; \
 	\
+	apk add --no-cache --virtual .cosign cosign --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community; \
 	apk add --no-cache --virtual .build-deps \
-		gnupg \
 		tar \
 		xz \
 		\
@@ -54,6 +56,9 @@ RUN set -eux; \
 	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	echo "$PYTHON_SHA256 *python.tar.xz" | sha256sum -c -; \
+	wget -O python.tar.xz.sigstore "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.sigstore"; \
+	cosign verify-blob python.tar.xz --bundle python.tar.xz.sigstore --new-bundle-format \
+		--certificate-identity ${CERTIFICATE_IDENTITY} --certificate-oidc-issuer ${CERTIFICATE_ISSUER}; \
 	mkdir -p /usr/src/python; \
 	tar --extract --directory /usr/src/python --strip-components=1 --file python.tar.xz; \
 	rm python.tar.xz; \
@@ -107,6 +112,7 @@ RUN set -eux; \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 		| xargs -rt apk add --no-network --virtual .python-rundeps \
 	; \
+	apk del --no-network .cosign; \
 	apk del --no-network .build-deps; \
 	\
 	export PYTHONDONTWRITEBYTECODE=1; \

--- a/3.14-rc/alpine3.20/Dockerfile
+++ b/3.14-rc/alpine3.20/Dockerfile
@@ -16,13 +16,15 @@ RUN set -eux; \
 		tzdata \
 	;
 
+ENV CERTIFICATE_ISSUER https://github.com/login/oauth
+ENV CERTIFICATE_IDENTITY hugo@python.org
 ENV PYTHON_VERSION 3.14.0a1
 ENV PYTHON_SHA256 3e464b0cbb7535e2db34262fd19a0a393d0e62be0f43b1513ed98379b054ead4
 
 RUN set -eux; \
 	\
+	apk add --no-cache --virtual .cosign cosign --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community; \
 	apk add --no-cache --virtual .build-deps \
-		gnupg \
 		tar \
 		xz \
 		\
@@ -54,6 +56,9 @@ RUN set -eux; \
 	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	echo "$PYTHON_SHA256 *python.tar.xz" | sha256sum -c -; \
+	wget -O python.tar.xz.sigstore "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.sigstore"; \
+	cosign verify-blob python.tar.xz --bundle python.tar.xz.sigstore --new-bundle-format \
+		--certificate-identity ${CERTIFICATE_IDENTITY} --certificate-oidc-issuer ${CERTIFICATE_ISSUER}; \
 	mkdir -p /usr/src/python; \
 	tar --extract --directory /usr/src/python --strip-components=1 --file python.tar.xz; \
 	rm python.tar.xz; \
@@ -107,6 +112,7 @@ RUN set -eux; \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 		| xargs -rt apk add --no-network --virtual .python-rundeps \
 	; \
+	apk del --no-network .cosign; \
 	apk del --no-network .build-deps; \
 	\
 	export PYTHONDONTWRITEBYTECODE=1; \

--- a/3.9/alpine3.19/Dockerfile
+++ b/3.9/alpine3.19/Dockerfile
@@ -21,14 +21,15 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568
+ENV CERTIFICATE_ISSUER https://github.com/login/oauth
+ENV CERTIFICATE_IDENTITY lukasz@langa.pl
 ENV PYTHON_VERSION 3.9.20
 ENV PYTHON_SHA256 6b281279efd85294d2d6993e173983a57464c0133956fbbb5536ec9646beaf0c
 
 RUN set -eux; \
 	\
+	apk add --no-cache --virtual .cosign cosign --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community; \
 	apk add --no-cache --virtual .build-deps \
-		gnupg \
 		tar \
 		xz \
 		\
@@ -60,12 +61,9 @@ RUN set -eux; \
 	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	echo "$PYTHON_SHA256 *python.tar.xz" | sha256sum -c -; \
-	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
-	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY"; \
-	gpg --batch --verify python.tar.xz.asc python.tar.xz; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" python.tar.xz.asc; \
+	wget -O python.tar.xz.sigstore "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.sigstore"; \
+	cosign verify-blob python.tar.xz --bundle python.tar.xz.sigstore --new-bundle-format \
+		--certificate-identity ${CERTIFICATE_IDENTITY} --certificate-oidc-issuer ${CERTIFICATE_ISSUER}; \
 	mkdir -p /usr/src/python; \
 	tar --extract --directory /usr/src/python --strip-components=1 --file python.tar.xz; \
 	rm python.tar.xz; \
@@ -118,6 +116,7 @@ RUN set -eux; \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 		| xargs -rt apk add --no-network --virtual .python-rundeps \
 	; \
+	apk del --no-network .cosign; \
 	apk del --no-network .build-deps; \
 	\
 	export PYTHONDONTWRITEBYTECODE=1; \

--- a/3.9/alpine3.20/Dockerfile
+++ b/3.9/alpine3.20/Dockerfile
@@ -21,14 +21,15 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568
+ENV CERTIFICATE_ISSUER https://github.com/login/oauth
+ENV CERTIFICATE_IDENTITY lukasz@langa.pl
 ENV PYTHON_VERSION 3.9.20
 ENV PYTHON_SHA256 6b281279efd85294d2d6993e173983a57464c0133956fbbb5536ec9646beaf0c
 
 RUN set -eux; \
 	\
+	apk add --no-cache --virtual .cosign cosign --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community; \
 	apk add --no-cache --virtual .build-deps \
-		gnupg \
 		tar \
 		xz \
 		\
@@ -60,12 +61,9 @@ RUN set -eux; \
 	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	echo "$PYTHON_SHA256 *python.tar.xz" | sha256sum -c -; \
-	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
-	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY"; \
-	gpg --batch --verify python.tar.xz.asc python.tar.xz; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" python.tar.xz.asc; \
+	wget -O python.tar.xz.sigstore "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.sigstore"; \
+	cosign verify-blob python.tar.xz --bundle python.tar.xz.sigstore --new-bundle-format \
+		--certificate-identity ${CERTIFICATE_IDENTITY} --certificate-oidc-issuer ${CERTIFICATE_ISSUER}; \
 	mkdir -p /usr/src/python; \
 	tar --extract --directory /usr/src/python --strip-components=1 --file python.tar.xz; \
 	rm python.tar.xz; \
@@ -118,6 +116,7 @@ RUN set -eux; \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 		| xargs -rt apk add --no-network --virtual .python-rundeps \
 	; \
+	apk del --no-network .cosign; \
 	apk del --no-network .build-deps; \
 	\
 	export PYTHONDONTWRITEBYTECODE=1; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -52,13 +52,54 @@ RUN set -eux; \
 {{ ) end -}}
 
 {{
+	def should_sigstore:
+		env.variant | startswith("alpine")
+	;
 	def should_pgp:
 		# https://github.com/docker-library/python/issues/977
 		# https://peps.python.org/pep-0761/
 		# https://discuss.python.org/t/pep-761-deprecating-pgp-signatures-for-cpython-artifacts/67180
 		rcVersion | IN("3.9", "3.10", "3.11", "3.12", "3.13")
 -}}
-{{ if should_pgp then ( -}}
+{{ if should_sigstore then ( -}}
+ENV CERTIFICATE_ISSUER {{
+       {
+               "3.9": "https://github.com/login/oauth",
+               "3.10": "https://accounts.google.com",
+               "3.11": "https://accounts.google.com",
+               "3.12": "https://accounts.google.com",
+               "3.13": "https://accounts.google.com",
+               "3.14": "https://github.com/login/oauth"
+       }[rcVersion]
+}}
+ENV CERTIFICATE_IDENTITY {{
+       {
+               # release manager: Łukasz Langa
+               "3.9": "lukasz@langa.pl",
+               # https://peps.python.org/pep-0596/#release-manager-and-crew
+
+               # release manager: Pablo Galindo Salgado
+               "3.10": "pablogsal@python.org",
+               # https://peps.python.org/pep-0619/#release-manager-and-crew
+
+               # release manager: Pablo Galindo Salgado
+               "3.11": "pablogsal@python.org",
+               # https://peps.python.org/pep-0664/#release-manager-and-crew
+
+               # release manager: Thomas Wouters
+               "3.12": "thomas@python.org",
+               # https://peps.python.org/pep-0693/#release-manager-and-crew
+
+               # release manager: Thomas Wouters
+               "3.13": "thomas@python.org",
+               # https://peps.python.org/pep-0719/#release-manager-and-crew
+
+               # release manager: Hugo van Kemenade
+               "3.14": "hugo@python.org"
+               # https://peps.python.org/pep-0745/#release-manager-and-crew
+       }[rcVersion]
+}}
+{{ ) elif should_pgp then ( -}}
 ENV GPG_KEY {{
 	{
 		# gpg: key B26995E310250568: public key "\xc5\x81ukasz Langa (GPG langa.pl) <lukasz@langa.pl>" imported
@@ -91,8 +132,8 @@ ENV PYTHON_SHA256 {{ .checksums.source.sha256 }}
 RUN set -eux; \
 	\
 {{ if is_alpine then ( -}}
+	apk add --no-cache --virtual .cosign cosign --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community; \
 	apk add --no-cache --virtual .build-deps \
-		gnupg \
 		tar \
 		xz \
 		\
@@ -154,7 +195,11 @@ RUN set -eux; \
 {{ if .checksums.source.sha256 then ( -}}
 	echo "$PYTHON_SHA256 *python.tar.xz" | sha256sum -c -; \
 {{ ) else "" end -}}
-{{ if should_pgp then ( -}}
+{{ if should_sigstore then ( -}}
+	wget -O python.tar.xz.sigstore "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.sigstore"; \
+	cosign verify-blob python.tar.xz --bundle python.tar.xz.sigstore --new-bundle-format \
+		--certificate-identity ${CERTIFICATE_IDENTITY} --certificate-oidc-issuer ${CERTIFICATE_ISSUER}; \
+{{ ) elif should_pgp then ( -}}
 	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
 	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY"; \
@@ -244,6 +289,7 @@ RUN set -eux; \
 		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 		| xargs -rt apk add --no-network --virtual .python-rundeps \
 	; \
+	apk del --no-network .cosign; \
 	apk del --no-network .build-deps; \
 {{ ) else ( -}}
 	ldconfig; \


### PR DESCRIPTION
All supported python releases now have associated sigstore files available.

This enables sigstore verification in the alpine images using cosign.
Unfortunately cosign 2.4+ is required which is only available in edge, package seems to work fine on 3.19/3.20.

Cosign is removed once the build completes.