### PR TITLE
Remove i386 from 3.14 (for now)

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -148,6 +148,12 @@ for version; do
 				;;
 		esac
 
+		if [ "$fullVersion" = '3.14.0a1' ]; then
+			# https://github.com/python/cpython/issues/125535 - 3.14.0a1 fails to build on i386
+			# https://github.com/python/cpython/pull/125244 (already fixed for the next release)
+			variantArches="$(sed <<<" $variantArches " -e 's/ i386 / /g')"
+		fi
+
 		sharedTags=()
 		for windowsShared in windowsservercore nanoserver; do
 			if [[ "$variant" == "$windowsShared"* ]]; then


### PR DESCRIPTION
There's a compilation error in 3.14.0a1 on 32bit x86 Linux that was caught before the release but 32bit x86 Linux is not a "tiered platform" (per PEP 11 / https://peps.python.org/pep-0011), so the fix didn't get in until post-release and should be in the next version (whatever that ends up being; 3.14.0a2, etc).

See https://github.com/python/cpython/issues/125535 and https://github.com/python/cpython/pull/125244