### PR TITLE
Add Alpine 3.21 variant

### DIFF
--- a/3.10/alpine3.21/Dockerfile
+++ b/3.10/alpine3.21/Dockerfile
@@ -4,10 +4,15 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.19
+FROM alpine:3.21
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
+
+# cannot remove LANG even though https://bugs.python.org/issue19846 is fixed
+# last attempted removal of LANG broke many users:
+# https://github.com/docker-library/python/pull/570
+ENV LANG C.UTF-8
 
 # runtime dependencies
 RUN set -eux; \
@@ -16,8 +21,9 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV PYTHON_VERSION 3.14.0a2
-ENV PYTHON_SHA256 2ff9e10147342b3efd69f5cd9cc06ec46250f2a046587599d18e2cac69c05920
+ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
+ENV PYTHON_VERSION 3.10.16
+ENV PYTHON_SHA256 bfb249609990220491a1b92850a07135ed0831e41738cf681d63cf01b2a8fbd1
 
 RUN set -eux; \
 	\
@@ -53,6 +59,12 @@ RUN set -eux; \
 	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	echo "$PYTHON_SHA256 *python.tar.xz" | sha256sum -c -; \
+	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
+	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY"; \
+	gpg --batch --verify python.tar.xz.asc python.tar.xz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" python.tar.xz.asc; \
 	mkdir -p /usr/src/python; \
 	tar --extract --directory /usr/src/python --strip-components=1 --file python.tar.xz; \
 	rm python.tar.xz; \
@@ -106,6 +118,14 @@ RUN set -eux; \
 	\
 	export PYTHONDONTWRITEBYTECODE=1; \
 	python3 --version; \
+	\
+	pip3 install \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		--no-compile \
+		'setuptools==65.5.1' \
+		wheel \
+	; \
 	pip3 --version
 
 # make some useful symlinks that are expected to exist ("/usr/local/bin/python" and friends)

--- a/3.11/alpine3.21/Dockerfile
+++ b/3.11/alpine3.21/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.19
+FROM alpine:3.21
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH

--- a/3.12/alpine3.21/Dockerfile
+++ b/3.12/alpine3.21/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.19
+FROM alpine:3.21
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
@@ -21,9 +21,9 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
-ENV PYTHON_VERSION 3.10.16
-ENV PYTHON_SHA256 bfb249609990220491a1b92850a07135ed0831e41738cf681d63cf01b2a8fbd1
+ENV GPG_KEY 7169605F62C751356D054A26A821E680E5FA6305
+ENV PYTHON_VERSION 3.12.8
+ENV PYTHON_SHA256 c909157bb25ec114e5869124cc2a9c4a4d4c1e957ca4ff553f1edc692101154e
 
 RUN set -eux; \
 	\
@@ -118,14 +118,6 @@ RUN set -eux; \
 	\
 	export PYTHONDONTWRITEBYTECODE=1; \
 	python3 --version; \
-	\
-	pip3 install \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		--no-compile \
-		'setuptools==65.5.1' \
-		wheel \
-	; \
 	pip3 --version
 
 # make some useful symlinks that are expected to exist ("/usr/local/bin/python" and friends)

--- a/3.13/alpine3.21/Dockerfile
+++ b/3.13/alpine3.21/Dockerfile
@@ -4,15 +4,10 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.19
+FROM alpine:3.21
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
-
-# cannot remove LANG even though https://bugs.python.org/issue19846 is fixed
-# last attempted removal of LANG broke many users:
-# https://github.com/docker-library/python/pull/570
-ENV LANG C.UTF-8
 
 # runtime dependencies
 RUN set -eux; \
@@ -21,9 +16,9 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568
-ENV PYTHON_VERSION 3.9.21
-ENV PYTHON_SHA256 3126f59592c9b0d798584755f2bf7b081fa1ca35ce7a6fea980108d752a05bb1
+ENV GPG_KEY 7169605F62C751356D054A26A821E680E5FA6305
+ENV PYTHON_VERSION 3.13.1
+ENV PYTHON_SHA256 9cf9427bee9e2242e3877dd0f6b641c1853ca461f39d6503ce260a59c80bf0d9
 
 RUN set -eux; \
 	\
@@ -76,6 +71,7 @@ RUN set -eux; \
 		--enable-loadable-sqlite-extensions \
 		--enable-option-checking=fatal \
 		--enable-shared \
+		--with-lto \
 		--with-ensurepip \
 	; \
 	nproc="$(nproc)"; \
@@ -117,14 +113,6 @@ RUN set -eux; \
 	\
 	export PYTHONDONTWRITEBYTECODE=1; \
 	python3 --version; \
-	\
-	pip3 install \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		--no-compile \
-		'setuptools==58.1.0' \
-		wheel \
-	; \
 	pip3 --version
 
 # make some useful symlinks that are expected to exist ("/usr/local/bin/python" and friends)

--- a/3.14-rc/alpine3.21/Dockerfile
+++ b/3.14-rc/alpine3.21/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.19
+FROM alpine:3.21
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
@@ -16,9 +16,8 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV GPG_KEY 7169605F62C751356D054A26A821E680E5FA6305
-ENV PYTHON_VERSION 3.13.1
-ENV PYTHON_SHA256 9cf9427bee9e2242e3877dd0f6b641c1853ca461f39d6503ce260a59c80bf0d9
+ENV PYTHON_VERSION 3.14.0a2
+ENV PYTHON_SHA256 2ff9e10147342b3efd69f5cd9cc06ec46250f2a046587599d18e2cac69c05920
 
 RUN set -eux; \
 	\
@@ -54,12 +53,6 @@ RUN set -eux; \
 	\
 	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	echo "$PYTHON_SHA256 *python.tar.xz" | sha256sum -c -; \
-	wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc"; \
-	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY"; \
-	gpg --batch --verify python.tar.xz.asc python.tar.xz; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" python.tar.xz.asc; \
 	mkdir -p /usr/src/python; \
 	tar --extract --directory /usr/src/python --strip-components=1 --file python.tar.xz; \
 	rm python.tar.xz; \

--- a/3.9/alpine3.21/Dockerfile
+++ b/3.9/alpine3.21/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.19
+FROM alpine:3.21
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
@@ -21,9 +21,9 @@ RUN set -eux; \
 		tzdata \
 	;
 
-ENV GPG_KEY 7169605F62C751356D054A26A821E680E5FA6305
-ENV PYTHON_VERSION 3.12.8
-ENV PYTHON_SHA256 c909157bb25ec114e5869124cc2a9c4a4d4c1e957ca4ff553f1edc692101154e
+ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568
+ENV PYTHON_VERSION 3.9.21
+ENV PYTHON_SHA256 3126f59592c9b0d798584755f2bf7b081fa1ca35ce7a6fea980108d752a05bb1
 
 RUN set -eux; \
 	\
@@ -76,7 +76,6 @@ RUN set -eux; \
 		--enable-loadable-sqlite-extensions \
 		--enable-option-checking=fatal \
 		--enable-shared \
-		--with-lto \
 		--with-ensurepip \
 	; \
 	nproc="$(nproc)"; \
@@ -118,6 +117,14 @@ RUN set -eux; \
 	\
 	export PYTHONDONTWRITEBYTECODE=1; \
 	python3 --version; \
+	\
+	pip3 install \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		--no-compile \
+		'setuptools==58.1.0' \
+		wheel \
+	; \
 	pip3 --version
 
 # make some useful symlinks that are expected to exist ("/usr/local/bin/python" and friends)

--- a/versions.json
+++ b/versions.json
@@ -13,8 +13,8 @@
       "slim-bookworm",
       "bullseye",
       "slim-bullseye",
-      "alpine3.20",
-      "alpine3.19"
+      "alpine3.21",
+      "alpine3.20"
     ],
     "version": "3.10.16"
   },
@@ -32,8 +32,8 @@
       "slim-bookworm",
       "bullseye",
       "slim-bullseye",
-      "alpine3.20",
-      "alpine3.19"
+      "alpine3.21",
+      "alpine3.20"
     ],
     "version": "3.11.11"
   },
@@ -51,8 +51,8 @@
       "slim-bookworm",
       "bullseye",
       "slim-bullseye",
+      "alpine3.21",
       "alpine3.20",
-      "alpine3.19",
       "windows/windowsservercore-ltsc2022",
       "windows/windowsservercore-1809"
     ],
@@ -72,8 +72,8 @@
       "slim-bookworm",
       "bullseye",
       "slim-bullseye",
+      "alpine3.21",
       "alpine3.20",
-      "alpine3.19",
       "windows/windowsservercore-ltsc2022",
       "windows/windowsservercore-1809"
     ],
@@ -93,8 +93,8 @@
       "slim-bookworm",
       "bullseye",
       "slim-bullseye",
+      "alpine3.21",
       "alpine3.20",
-      "alpine3.19",
       "windows/windowsservercore-ltsc2022",
       "windows/windowsservercore-1809"
     ],
@@ -114,8 +114,8 @@
       "slim-bookworm",
       "bullseye",
       "slim-bullseye",
-      "alpine3.20",
-      "alpine3.19"
+      "alpine3.21",
+      "alpine3.20"
     ],
     "version": "3.9.21"
   }

--- a/versions.sh
+++ b/versions.sh
@@ -200,8 +200,8 @@ for version in "${versions[@]}"; do
 					empty
 				| ., "slim-" + .), # https://github.com/docker-library/ruby/pull/142#issuecomment-320012893
 				(
+					"3.21",
 					"3.20",
-					"3.19",
 					empty
 				| "alpine" + .),
 				if env.hasWindows != "" then


### PR DESCRIPTION
Modelled after #925.

Requires https://github.com/docker-library/official-images/pull/18024.

This PR adds a variant for Alpine 3.21 and drops the 3.19 variant at the same time.

See also https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.21.0.