### PR TITLE
Compile with `no-omit-frame-pointer`

### DIFF
--- a/3.12/alpine3.20/Dockerfile
+++ b/3.12/alpine3.20/Dockerfile
@@ -84,6 +84,10 @@ RUN set -eux; \
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
 	LDFLAGS="${LDFLAGS:--Wl},--strip-all"; \
+# https://docs.python.org/3.12/howto/perf_profiling.html
+# But don't enable frame-pointers on 32bit x86 due to performance drop.
+# https://github.com/docker-library/python/pull/1000#issuecomment-2597021615
+	test "$gnuArch" != 'i686-linux-gnu' && EXTRA_CFLAGS="${EXTRA_CFLAGS:-} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"; \
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \

--- a/3.12/alpine3.21/Dockerfile
+++ b/3.12/alpine3.21/Dockerfile
@@ -84,6 +84,10 @@ RUN set -eux; \
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
 	LDFLAGS="${LDFLAGS:--Wl},--strip-all"; \
+# https://docs.python.org/3.12/howto/perf_profiling.html
+# But don't enable frame-pointers on 32bit x86 due to performance drop.
+# https://github.com/docker-library/python/pull/1000#issuecomment-2597021615
+	test "$gnuArch" != 'i686-linux-gnu' && EXTRA_CFLAGS="${EXTRA_CFLAGS:-} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"; \
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \

--- a/3.12/bookworm/Dockerfile
+++ b/3.12/bookworm/Dockerfile
@@ -56,6 +56,10 @@ RUN set -eux; \
 	nproc="$(nproc)"; \
 	EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \
 	LDFLAGS="$(dpkg-buildflags --get LDFLAGS)"; \
+# https://docs.python.org/3.12/howto/perf_profiling.html
+# But don't enable frame-pointers on 32bit x86 due to performance drop.
+# https://github.com/docker-library/python/pull/1000#issuecomment-2597021615
+	test "$gnuArch" != 'i686-linux-gnu' && EXTRA_CFLAGS="${EXTRA_CFLAGS:-} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"; \
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \

--- a/3.12/bullseye/Dockerfile
+++ b/3.12/bullseye/Dockerfile
@@ -56,6 +56,10 @@ RUN set -eux; \
 	nproc="$(nproc)"; \
 	EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \
 	LDFLAGS="$(dpkg-buildflags --get LDFLAGS)"; \
+# https://docs.python.org/3.12/howto/perf_profiling.html
+# But don't enable frame-pointers on 32bit x86 due to performance drop.
+# https://github.com/docker-library/python/pull/1000#issuecomment-2597021615
+	test "$gnuArch" != 'i686-linux-gnu' && EXTRA_CFLAGS="${EXTRA_CFLAGS:-} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"; \
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \

--- a/3.12/slim-bookworm/Dockerfile
+++ b/3.12/slim-bookworm/Dockerfile
@@ -82,6 +82,10 @@ RUN set -eux; \
 	EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \
 	LDFLAGS="$(dpkg-buildflags --get LDFLAGS)"; \
 	LDFLAGS="${LDFLAGS:--Wl},--strip-all"; \
+# https://docs.python.org/3.12/howto/perf_profiling.html
+# But don't enable frame-pointers on 32bit x86 due to performance drop.
+# https://github.com/docker-library/python/pull/1000#issuecomment-2597021615
+	test "$gnuArch" != 'i686-linux-gnu' && EXTRA_CFLAGS="${EXTRA_CFLAGS:-} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"; \
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \

--- a/3.12/slim-bullseye/Dockerfile
+++ b/3.12/slim-bullseye/Dockerfile
@@ -82,6 +82,10 @@ RUN set -eux; \
 	EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \
 	LDFLAGS="$(dpkg-buildflags --get LDFLAGS)"; \
 	LDFLAGS="${LDFLAGS:--Wl},--strip-all"; \
+# https://docs.python.org/3.12/howto/perf_profiling.html
+# But don't enable frame-pointers on 32bit x86 due to performance drop.
+# https://github.com/docker-library/python/pull/1000#issuecomment-2597021615
+	test "$gnuArch" != 'i686-linux-gnu' && EXTRA_CFLAGS="${EXTRA_CFLAGS:-} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"; \
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \

--- a/3.13/alpine3.20/Dockerfile
+++ b/3.13/alpine3.20/Dockerfile
@@ -79,6 +79,10 @@ RUN set -eux; \
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
 	LDFLAGS="${LDFLAGS:--Wl},--strip-all"; \
+# https://docs.python.org/3.12/howto/perf_profiling.html
+# But don't enable frame-pointers on 32bit x86 due to performance drop.
+# https://github.com/docker-library/python/pull/1000#issuecomment-2597021615
+	test "$gnuArch" != 'i686-linux-gnu' && EXTRA_CFLAGS="${EXTRA_CFLAGS:-} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"; \
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \

--- a/3.13/alpine3.21/Dockerfile
+++ b/3.13/alpine3.21/Dockerfile
@@ -79,6 +79,10 @@ RUN set -eux; \
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
 	LDFLAGS="${LDFLAGS:--Wl},--strip-all"; \
+# https://docs.python.org/3.12/howto/perf_profiling.html
+# But don't enable frame-pointers on 32bit x86 due to performance drop.
+# https://github.com/docker-library/python/pull/1000#issuecomment-2597021615
+	test "$gnuArch" != 'i686-linux-gnu' && EXTRA_CFLAGS="${EXTRA_CFLAGS:-} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"; \
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \

--- a/3.13/bookworm/Dockerfile
+++ b/3.13/bookworm/Dockerfile
@@ -51,6 +51,10 @@ RUN set -eux; \
 	nproc="$(nproc)"; \
 	EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \
 	LDFLAGS="$(dpkg-buildflags --get LDFLAGS)"; \
+# https://docs.python.org/3.12/howto/perf_profiling.html
+# But don't enable frame-pointers on 32bit x86 due to performance drop.
+# https://github.com/docker-library/python/pull/1000#issuecomment-2597021615
+	test "$gnuArch" != 'i686-linux-gnu' && EXTRA_CFLAGS="${EXTRA_CFLAGS:-} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"; \
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \

--- a/3.13/bullseye/Dockerfile
+++ b/3.13/bullseye/Dockerfile
@@ -51,6 +51,10 @@ RUN set -eux; \
 	nproc="$(nproc)"; \
 	EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \
 	LDFLAGS="$(dpkg-buildflags --get LDFLAGS)"; \
+# https://docs.python.org/3.12/howto/perf_profiling.html
+# But don't enable frame-pointers on 32bit x86 due to performance drop.
+# https://github.com/docker-library/python/pull/1000#issuecomment-2597021615
+	test "$gnuArch" != 'i686-linux-gnu' && EXTRA_CFLAGS="${EXTRA_CFLAGS:-} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"; \
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \

--- a/3.13/slim-bookworm/Dockerfile
+++ b/3.13/slim-bookworm/Dockerfile
@@ -77,6 +77,10 @@ RUN set -eux; \
 	EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \
 	LDFLAGS="$(dpkg-buildflags --get LDFLAGS)"; \
 	LDFLAGS="${LDFLAGS:--Wl},--strip-all"; \
+# https://docs.python.org/3.12/howto/perf_profiling.html
+# But don't enable frame-pointers on 32bit x86 due to performance drop.
+# https://github.com/docker-library/python/pull/1000#issuecomment-2597021615
+	test "$gnuArch" != 'i686-linux-gnu' && EXTRA_CFLAGS="${EXTRA_CFLAGS:-} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"; \
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \

--- a/3.13/slim-bullseye/Dockerfile
+++ b/3.13/slim-bullseye/Dockerfile
@@ -77,6 +77,10 @@ RUN set -eux; \
 	EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \
 	LDFLAGS="$(dpkg-buildflags --get LDFLAGS)"; \
 	LDFLAGS="${LDFLAGS:--Wl},--strip-all"; \
+# https://docs.python.org/3.12/howto/perf_profiling.html
+# But don't enable frame-pointers on 32bit x86 due to performance drop.
+# https://github.com/docker-library/python/pull/1000#issuecomment-2597021615
+	test "$gnuArch" != 'i686-linux-gnu' && EXTRA_CFLAGS="${EXTRA_CFLAGS:-} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"; \
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \

--- a/3.14-rc/alpine3.20/Dockerfile
+++ b/3.14-rc/alpine3.20/Dockerfile
@@ -72,6 +72,10 @@ RUN set -eux; \
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
 	LDFLAGS="${LDFLAGS:--Wl},--strip-all"; \
+# https://docs.python.org/3.12/howto/perf_profiling.html
+# But don't enable frame-pointers on 32bit x86 due to performance drop.
+# https://github.com/docker-library/python/pull/1000#issuecomment-2597021615
+	test "$gnuArch" != 'i686-linux-gnu' && EXTRA_CFLAGS="${EXTRA_CFLAGS:-} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"; \
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \

--- a/3.14-rc/alpine3.21/Dockerfile
+++ b/3.14-rc/alpine3.21/Dockerfile
@@ -72,6 +72,10 @@ RUN set -eux; \
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 	EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"; \
 	LDFLAGS="${LDFLAGS:--Wl},--strip-all"; \
+# https://docs.python.org/3.12/howto/perf_profiling.html
+# But don't enable frame-pointers on 32bit x86 due to performance drop.
+# https://github.com/docker-library/python/pull/1000#issuecomment-2597021615
+	test "$gnuArch" != 'i686-linux-gnu' && EXTRA_CFLAGS="${EXTRA_CFLAGS:-} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"; \
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \

--- a/3.14-rc/bookworm/Dockerfile
+++ b/3.14-rc/bookworm/Dockerfile
@@ -44,6 +44,10 @@ RUN set -eux; \
 	nproc="$(nproc)"; \
 	EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \
 	LDFLAGS="$(dpkg-buildflags --get LDFLAGS)"; \
+# https://docs.python.org/3.12/howto/perf_profiling.html
+# But don't enable frame-pointers on 32bit x86 due to performance drop.
+# https://github.com/docker-library/python/pull/1000#issuecomment-2597021615
+	test "$gnuArch" != 'i686-linux-gnu' && EXTRA_CFLAGS="${EXTRA_CFLAGS:-} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"; \
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \

--- a/3.14-rc/bullseye/Dockerfile
+++ b/3.14-rc/bullseye/Dockerfile
@@ -44,6 +44,10 @@ RUN set -eux; \
 	nproc="$(nproc)"; \
 	EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \
 	LDFLAGS="$(dpkg-buildflags --get LDFLAGS)"; \
+# https://docs.python.org/3.12/howto/perf_profiling.html
+# But don't enable frame-pointers on 32bit x86 due to performance drop.
+# https://github.com/docker-library/python/pull/1000#issuecomment-2597021615
+	test "$gnuArch" != 'i686-linux-gnu' && EXTRA_CFLAGS="${EXTRA_CFLAGS:-} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"; \
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \

--- a/3.14-rc/slim-bookworm/Dockerfile
+++ b/3.14-rc/slim-bookworm/Dockerfile
@@ -70,6 +70,10 @@ RUN set -eux; \
 	EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \
 	LDFLAGS="$(dpkg-buildflags --get LDFLAGS)"; \
 	LDFLAGS="${LDFLAGS:--Wl},--strip-all"; \
+# https://docs.python.org/3.12/howto/perf_profiling.html
+# But don't enable frame-pointers on 32bit x86 due to performance drop.
+# https://github.com/docker-library/python/pull/1000#issuecomment-2597021615
+	test "$gnuArch" != 'i686-linux-gnu' && EXTRA_CFLAGS="${EXTRA_CFLAGS:-} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"; \
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \

--- a/3.14-rc/slim-bullseye/Dockerfile
+++ b/3.14-rc/slim-bullseye/Dockerfile
@@ -70,6 +70,10 @@ RUN set -eux; \
 	EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \
 	LDFLAGS="$(dpkg-buildflags --get LDFLAGS)"; \
 	LDFLAGS="${LDFLAGS:--Wl},--strip-all"; \
+# https://docs.python.org/3.12/howto/perf_profiling.html
+# But don't enable frame-pointers on 32bit x86 due to performance drop.
+# https://github.com/docker-library/python/pull/1000#issuecomment-2597021615
+	test "$gnuArch" != 'i686-linux-gnu' && EXTRA_CFLAGS="${EXTRA_CFLAGS:-} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"; \
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -198,6 +198,15 @@ RUN set -eux; \
 {{ if is_slim or is_alpine then ( -}}
 	LDFLAGS="${LDFLAGS:--Wl},--strip-all"; \
 {{ ) else "" end -}}
+{{
+	# Enabling frame-pointers only makes sense for Python 3.12 and newer as those have perf profiler support
+	if rcVersion | IN("3.9", "3.10", "3.11") then "" else (
+-}}
+# https://docs.python.org/3.12/howto/perf_profiling.html
+# But don't enable frame-pointers on 32bit x86 due to performance drop.
+# https://github.com/docker-library/python/pull/1000#issuecomment-2597021615
+	test "$gnuArch" != 'i686-linux-gnu' && EXTRA_CFLAGS="${EXTRA_CFLAGS:-} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"; \
+{{ ) end -}}
 	make -j "$nproc" \
 		"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
 		"LDFLAGS=${LDFLAGS:-}" \


### PR DESCRIPTION
This adds support for profiling Python 3.12 and newer using Linux `perf` command.

* https://docs.python.org/3.12/howto/perf_profiling.html

Fixes: #995