### PR TITLE
Remove s390x from Alpine variants on 3.14(+)

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -136,22 +136,24 @@ for version; do
 				;;
 		esac
 
+		# https://github.com/docker-library/python/pull/931 (riscv64 builds on 3.11+ take way too long 😞)
 		case "$version" in
-			3.9) ;;
-			*)
-				if [ "$version" != '3.10' ]; then
-					# https://github.com/docker-library/python/pull/931
-					variantArches="$(sed <<<" $variantArches " -e 's/ riscv64 / /g')"
-				fi
-				# https://github.com/python/cpython/issues/93619 + https://peps.python.org/pep-0011/
-				variantArches="$(sed <<<" $variantArches " -e 's/ mips64le / /g')"
-				;;
+			3.9 | 3.10) ;;
+			*) variantArches="$(sed <<<" $variantArches " -e 's/ riscv64 / /g')" ;;
 		esac
 
-		if [ "$fullVersion" = '3.14.0a1' ]; then
-			# https://github.com/python/cpython/issues/125535 - 3.14.0a1 fails to build on i386
-			# https://github.com/python/cpython/pull/125244 (already fixed for the next release)
-			variantArches="$(sed <<<" $variantArches " -e 's/ i386 / /g')"
+		# https://github.com/python/cpython/issues/93619 (Linking error when building 3.11 beta on mips64le) + https://peps.python.org/pep-0011/ (mips is not even tier 3)
+		case "$version" in
+			3.9) ;;
+			*) variantArches="$(sed <<<" $variantArches " -e 's/ mips64le / /g')" ;;
+		esac
+
+		# https://github.com/docker-library/python/issues/1014 (ensurepip failing on s390x 3.14.0a6 Alpine images)
+		if [[ "$variant" == alpine* ]]; then
+			case "$version" in
+				3.9 | 3.10 | 3.11 | 3.12 | 3.13) ;;
+				*) variantArches="$(sed <<<" $variantArches " -e 's/ s390x / /g')" ;;
+			esac
 		fi
 
 		sharedTags=()


### PR DESCRIPTION
I've also refactored all our "exclude an architecture in certain combinations" sections to have slightly more context in-file and to be more targeted/focused on a single issue so they're easier to read.

```diff
$ diff -u <(bashbrew cat python) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63	2025-04-01 15:12:40.298947543 -0700
+++ /dev/fd/62	2025-04-01 15:12:40.298947543 -0700
@@ -24,12 +24,12 @@
 Directory: 3.14-rc/slim-bullseye

 Tags: 3.14.0a6-alpine3.21, 3.14-rc-alpine3.21, 3.14.0a6-alpine, 3.14-rc-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 0bd97693f7105bfb6f0ef81020c6d81ade21bc0b
 Directory: 3.14-rc/alpine3.21

 Tags: 3.14.0a6-alpine3.20, 3.14-rc-alpine3.20
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 0bd97693f7105bfb6f0ef81020c6d81ade21bc0b
 Directory: 3.14-rc/alpine3.20

```

Closes https://github.com/docker-library/python/issues/1014