### PR TITLE
fix: Upgrade setuptools to 70.1.0+ to support wheel v0.46.0 compatibility

### DIFF
--- a/3.10/alpine3.20/Dockerfile
+++ b/3.10/alpine3.20/Dockerfile
@@ -123,7 +123,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==70.1.0' \
 		wheel \
 	; \
 	pip3 --version

--- a/3.10/alpine3.21/Dockerfile
+++ b/3.10/alpine3.21/Dockerfile
@@ -123,7 +123,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==70.1.0' \
 		wheel \
 	; \
 	pip3 --version

--- a/3.10/bookworm/Dockerfile
+++ b/3.10/bookworm/Dockerfile
@@ -95,7 +95,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==70.1.0' \
 		wheel \
 	; \
 	pip3 --version

--- a/3.10/bullseye/Dockerfile
+++ b/3.10/bullseye/Dockerfile
@@ -95,7 +95,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==70.1.0' \
 		wheel \
 	; \
 	pip3 --version

--- a/3.10/slim-bookworm/Dockerfile
+++ b/3.10/slim-bookworm/Dockerfile
@@ -128,7 +128,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==70.1.0' \
 		wheel \
 	; \
 	pip3 --version

--- a/3.10/slim-bullseye/Dockerfile
+++ b/3.10/slim-bullseye/Dockerfile
@@ -128,7 +128,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==70.1.0' \
 		wheel \
 	; \
 	pip3 --version

--- a/3.11/alpine3.20/Dockerfile
+++ b/3.11/alpine3.20/Dockerfile
@@ -123,7 +123,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==70.1.0' \
 		wheel \
 	; \
 	pip3 --version

--- a/3.11/alpine3.21/Dockerfile
+++ b/3.11/alpine3.21/Dockerfile
@@ -123,7 +123,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==70.1.0' \
 		wheel \
 	; \
 	pip3 --version

--- a/3.11/bookworm/Dockerfile
+++ b/3.11/bookworm/Dockerfile
@@ -95,7 +95,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==70.1.0' \
 		wheel \
 	; \
 	pip3 --version

--- a/3.11/bullseye/Dockerfile
+++ b/3.11/bullseye/Dockerfile
@@ -95,7 +95,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==70.1.0' \
 		wheel \
 	; \
 	pip3 --version

--- a/3.11/slim-bookworm/Dockerfile
+++ b/3.11/slim-bookworm/Dockerfile
@@ -128,7 +128,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==70.1.0' \
 		wheel \
 	; \
 	pip3 --version

--- a/3.11/slim-bullseye/Dockerfile
+++ b/3.11/slim-bullseye/Dockerfile
@@ -128,7 +128,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==70.1.0' \
 		wheel \
 	; \
 	pip3 --version

--- a/3.9/alpine3.20/Dockerfile
+++ b/3.9/alpine3.20/Dockerfile
@@ -122,7 +122,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==58.1.0' \
+		'setuptools==70.1.0' \
 		wheel \
 	; \
 	pip3 --version

--- a/3.9/alpine3.21/Dockerfile
+++ b/3.9/alpine3.21/Dockerfile
@@ -122,7 +122,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==58.1.0' \
+		'setuptools==70.1.0' \
 		wheel \
 	; \
 	pip3 --version

--- a/3.9/bookworm/Dockerfile
+++ b/3.9/bookworm/Dockerfile
@@ -94,7 +94,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==58.1.0' \
+		'setuptools==70.1.0' \
 		wheel \
 	; \
 	pip3 --version

--- a/3.9/bullseye/Dockerfile
+++ b/3.9/bullseye/Dockerfile
@@ -94,7 +94,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==58.1.0' \
+		'setuptools==70.1.0' \
 		wheel \
 	; \
 	pip3 --version

--- a/3.9/slim-bookworm/Dockerfile
+++ b/3.9/slim-bookworm/Dockerfile
@@ -127,7 +127,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==58.1.0' \
+		'setuptools==70.1.0' \
 		wheel \
 	; \
 	pip3 --version

--- a/3.9/slim-bullseye/Dockerfile
+++ b/3.9/slim-bullseye/Dockerfile
@@ -127,7 +127,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==58.1.0' \
+		'setuptools==70.1.0' \
 		wheel \
 	; \
 	pip3 --version

--- a/versions.json
+++ b/versions.json
@@ -110,7 +110,7 @@
       }
     },
     "setuptools": {
-      "version": "58.1.0"
+      "version": "70.1.0"
     },
     "variants": [
       "bookworm",

--- a/versions.json
+++ b/versions.json
@@ -6,7 +6,7 @@
       }
     },
     "setuptools": {
-      "version": "65.5.1"
+      "version": "70.1.0"
     },
     "variants": [
       "bookworm",
@@ -25,7 +25,7 @@
       }
     },
     "setuptools": {
-      "version": "65.5.1"
+      "version": "70.1.0"
     },
     "variants": [
       "bookworm",

--- a/versions.sh
+++ b/versions.sh
@@ -171,11 +171,6 @@ for version in "${versions[@]}"; do
 				echo >&2 "error: $version: setuptools version ($setuptoolsVersion) seems to be invalid?"
 				exit 1
 			fi
-
-			# https://github.com/docker-library/python/issues/781 (TODO remove this if 3.10 and 3.11 embed a newer setuptools and this section no longer applies)
-			if [ "$setuptoolsVersion" = '65.5.0' ]; then
-				setuptoolsVersion='65.5.1'
-			fi
 			;;
 
 		*)


### PR DESCRIPTION
Fixes #1021

wheel: https://github.com/pypa/wheel/issues/662, https://github.com/pypa/wheel/issues/660

## Problem

After wheel v0.46.0 was released, `bdist_wheel` command migrate to `setupstools>=70.1.0`, [link](https://github.com/pypa/wheel/releases/tag/0.46.0), it became incompatible with setuptools versions below 70.1.0.

UPDATE: wheel yank v0.46.0 https://pypi.org/project/wheel/#history
discussion: https://github.com/pypa/wheel/issues/662#issuecomment-2789191942

## Solution

This PR upgrades setuptools to version 70.1.0 or higher in all Docker containers to ensure compatibility with wheel v0.46.0+.

