### PR TITLE
DNM: disable the GIL (experimental) in 3.13+

### DIFF
--- a/3.13/alpine3.20/Dockerfile
+++ b/3.13/alpine3.20/Dockerfile
@@ -73,6 +73,8 @@ RUN set -eux; \
 		--enable-shared \
 		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--with-lto') \
 		--with-ensurepip \
+# https://github.com/docker-library/python/issues/947
+		--disable-gil \
 	; \
 	nproc="$(nproc)"; \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()

--- a/3.13/alpine3.21/Dockerfile
+++ b/3.13/alpine3.21/Dockerfile
@@ -73,6 +73,8 @@ RUN set -eux; \
 		--enable-shared \
 		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--with-lto') \
 		--with-ensurepip \
+# https://github.com/docker-library/python/issues/947
+		--disable-gil \
 	; \
 	nproc="$(nproc)"; \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()

--- a/3.13/bookworm/Dockerfile
+++ b/3.13/bookworm/Dockerfile
@@ -47,6 +47,8 @@ RUN set -eux; \
 		--enable-shared \
 		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--with-lto') \
 		--with-ensurepip \
+# https://github.com/docker-library/python/issues/947
+		--disable-gil \
 	; \
 	nproc="$(nproc)"; \
 	EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \

--- a/3.13/bullseye/Dockerfile
+++ b/3.13/bullseye/Dockerfile
@@ -47,6 +47,8 @@ RUN set -eux; \
 		--enable-shared \
 		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--with-lto') \
 		--with-ensurepip \
+# https://github.com/docker-library/python/issues/947
+		--disable-gil \
 	; \
 	nproc="$(nproc)"; \
 	EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \

--- a/3.13/slim-bookworm/Dockerfile
+++ b/3.13/slim-bookworm/Dockerfile
@@ -72,6 +72,8 @@ RUN set -eux; \
 		--enable-shared \
 		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--with-lto') \
 		--with-ensurepip \
+# https://github.com/docker-library/python/issues/947
+		--disable-gil \
 	; \
 	nproc="$(nproc)"; \
 	EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \

--- a/3.13/slim-bullseye/Dockerfile
+++ b/3.13/slim-bullseye/Dockerfile
@@ -72,6 +72,8 @@ RUN set -eux; \
 		--enable-shared \
 		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--with-lto') \
 		--with-ensurepip \
+# https://github.com/docker-library/python/issues/947
+		--disable-gil \
 	; \
 	nproc="$(nproc)"; \
 	EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \

--- a/3.14-rc/alpine3.20/Dockerfile
+++ b/3.14-rc/alpine3.20/Dockerfile
@@ -66,6 +66,8 @@ RUN set -eux; \
 		--enable-shared \
 		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--with-lto') \
 		--with-ensurepip \
+# https://github.com/docker-library/python/issues/947
+		--disable-gil \
 	; \
 	nproc="$(nproc)"; \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()

--- a/3.14-rc/alpine3.21/Dockerfile
+++ b/3.14-rc/alpine3.21/Dockerfile
@@ -66,6 +66,8 @@ RUN set -eux; \
 		--enable-shared \
 		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--with-lto') \
 		--with-ensurepip \
+# https://github.com/docker-library/python/issues/947
+		--disable-gil \
 	; \
 	nproc="$(nproc)"; \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()

--- a/3.14-rc/bookworm/Dockerfile
+++ b/3.14-rc/bookworm/Dockerfile
@@ -40,6 +40,8 @@ RUN set -eux; \
 		--enable-shared \
 		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--with-lto') \
 		--with-ensurepip \
+# https://github.com/docker-library/python/issues/947
+		--disable-gil \
 	; \
 	nproc="$(nproc)"; \
 	EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \

--- a/3.14-rc/bullseye/Dockerfile
+++ b/3.14-rc/bullseye/Dockerfile
@@ -40,6 +40,8 @@ RUN set -eux; \
 		--enable-shared \
 		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--with-lto') \
 		--with-ensurepip \
+# https://github.com/docker-library/python/issues/947
+		--disable-gil \
 	; \
 	nproc="$(nproc)"; \
 	EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \

--- a/3.14-rc/slim-bookworm/Dockerfile
+++ b/3.14-rc/slim-bookworm/Dockerfile
@@ -65,6 +65,8 @@ RUN set -eux; \
 		--enable-shared \
 		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--with-lto') \
 		--with-ensurepip \
+# https://github.com/docker-library/python/issues/947
+		--disable-gil \
 	; \
 	nproc="$(nproc)"; \
 	EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \

--- a/3.14-rc/slim-bullseye/Dockerfile
+++ b/3.14-rc/slim-bullseye/Dockerfile
@@ -65,6 +65,8 @@ RUN set -eux; \
 		--enable-shared \
 		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--with-lto') \
 		--with-ensurepip \
+# https://github.com/docker-library/python/issues/947
+		--disable-gil \
 	; \
 	nproc="$(nproc)"; \
 	EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -186,6 +186,10 @@ RUN set -eux; \
 		$(test "$gnuArch" != 'riscv64-linux-musl' && echo '--with-lto') \
 {{ ) end -}}
 		--with-ensurepip \
+{{ if IN(rcVersion; "3.9", "3.10", "3.11", "3.12") then "" else ( -}}
+# https://github.com/docker-library/python/issues/947
+		--disable-gil \
+{{ ) end -}}
 	; \
 	nproc="$(nproc)"; \
 {{ if is_alpine then ( -}}


### PR DESCRIPTION
This is for testing, not for merging.

See:
- https://github.com/docker-library/python/issues/947