### PR TITLE
upgrade versions of setup tools

### DIFF
--- a/3.10/alpine3.21/Dockerfile
+++ b/3.10/alpine3.21/Dockerfile
@@ -123,7 +123,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==78.1.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.10/alpine3.22/Dockerfile
+++ b/3.10/alpine3.22/Dockerfile
@@ -123,7 +123,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==78.1.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.10/bookworm/Dockerfile
+++ b/3.10/bookworm/Dockerfile
@@ -95,7 +95,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==78.1.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.10/bullseye/Dockerfile
+++ b/3.10/bullseye/Dockerfile
@@ -95,7 +95,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==78.1.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.10/slim-bookworm/Dockerfile
+++ b/3.10/slim-bookworm/Dockerfile
@@ -128,7 +128,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==78.1.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.10/slim-bullseye/Dockerfile
+++ b/3.10/slim-bullseye/Dockerfile
@@ -128,7 +128,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==78.1.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.11/alpine3.21/Dockerfile
+++ b/3.11/alpine3.21/Dockerfile
@@ -123,7 +123,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==78.1.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.11/alpine3.22/Dockerfile
+++ b/3.11/alpine3.22/Dockerfile
@@ -123,7 +123,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==78.1.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.11/bookworm/Dockerfile
+++ b/3.11/bookworm/Dockerfile
@@ -95,7 +95,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==78.1.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.11/bullseye/Dockerfile
+++ b/3.11/bullseye/Dockerfile
@@ -95,7 +95,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==78.1.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.11/slim-bookworm/Dockerfile
+++ b/3.11/slim-bookworm/Dockerfile
@@ -128,7 +128,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==78.1.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.11/slim-bullseye/Dockerfile
+++ b/3.11/slim-bullseye/Dockerfile
@@ -128,7 +128,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==78.1.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/versions.json
+++ b/versions.json
@@ -6,7 +6,7 @@
       }
     },
     "setuptools": {
-      "version": "65.5.1"
+      "version": "78.1.1"
     },
     "variants": [
       "bookworm",
@@ -25,7 +25,7 @@
       }
     },
     "setuptools": {
-      "version": "65.5.1"
+      "version": "78.1.1"
     },
     "variants": [
       "bookworm",


### PR DESCRIPTION
This upgrade will solved the issues of CVE-2025-47273 which had the high score on vulnerability database. 