### PR TITLE
Add back s390x for 3.14+

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -142,14 +142,6 @@ for version; do
 			*) variantArches="$(sed <<<" $variantArches " -e 's/ mips64le / /g')" ;;
 		esac
 
-		# https://github.com/docker-library/python/issues/1014 (ensurepip failing on s390x 3.14.0a6 Alpine images)
-		if [[ "$variant" == alpine* ]]; then
-			case "$version" in
-				3.9 | 3.10 | 3.11 | 3.12 | 3.13) ;;
-				*) variantArches="$(sed <<<" $variantArches " -e 's/ s390x / /g')" ;;
-			esac
-		fi
-
 		sharedTags=()
 		for windowsShared in windowsservercore nanoserver; do
 			if [[ "$variant" == "$windowsShared"* ]]; then


### PR DESCRIPTION
This adds back `s390x` for 3.14+ on Alpine because the error was fixed in https://github.com/python/cpython/pull/137175

This reverts https://github.com/docker-library/python/pull/1015.

Related refs: https://github.com/docker-library/python/issues/1014, https://github.com/python/cpython/issues/133801, and https://github.com/python/cpython/issues/137231