### PR TITLE
Bump 3.10 and 3.11

### DIFF
--- a/3.10/alpine3.21/Dockerfile
+++ b/3.10/alpine3.21/Dockerfile
@@ -22,8 +22,8 @@ RUN set -eux; \
 	;
 
 ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
-ENV PYTHON_VERSION 3.10.18
-ENV PYTHON_SHA256 ae665bc678abd9ab6a6e1573d2481625a53719bc517e9a634ed2b9fefae3817f
+ENV PYTHON_VERSION 3.10.19
+ENV PYTHON_SHA256 c8f4a596572201d81dd7df91f70e177e19a70f1d489968b54b5fbbf29a97c076
 
 RUN set -eux; \
 	\
@@ -122,7 +122,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==79.0.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.10/alpine3.22/Dockerfile
+++ b/3.10/alpine3.22/Dockerfile
@@ -22,8 +22,8 @@ RUN set -eux; \
 	;
 
 ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
-ENV PYTHON_VERSION 3.10.18
-ENV PYTHON_SHA256 ae665bc678abd9ab6a6e1573d2481625a53719bc517e9a634ed2b9fefae3817f
+ENV PYTHON_VERSION 3.10.19
+ENV PYTHON_SHA256 c8f4a596572201d81dd7df91f70e177e19a70f1d489968b54b5fbbf29a97c076
 
 RUN set -eux; \
 	\
@@ -122,7 +122,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==79.0.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.10/bookworm/Dockerfile
+++ b/3.10/bookworm/Dockerfile
@@ -25,8 +25,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
-ENV PYTHON_VERSION 3.10.18
-ENV PYTHON_SHA256 ae665bc678abd9ab6a6e1573d2481625a53719bc517e9a634ed2b9fefae3817f
+ENV PYTHON_VERSION 3.10.19
+ENV PYTHON_SHA256 c8f4a596572201d81dd7df91f70e177e19a70f1d489968b54b5fbbf29a97c076
 
 RUN set -eux; \
 	\
@@ -95,7 +95,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==79.0.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.10/slim-bookworm/Dockerfile
+++ b/3.10/slim-bookworm/Dockerfile
@@ -25,8 +25,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
-ENV PYTHON_VERSION 3.10.18
-ENV PYTHON_SHA256 ae665bc678abd9ab6a6e1573d2481625a53719bc517e9a634ed2b9fefae3817f
+ENV PYTHON_VERSION 3.10.19
+ENV PYTHON_SHA256 c8f4a596572201d81dd7df91f70e177e19a70f1d489968b54b5fbbf29a97c076
 
 RUN set -eux; \
 	\
@@ -129,7 +129,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==79.0.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.10/slim-trixie/Dockerfile
+++ b/3.10/slim-trixie/Dockerfile
@@ -25,8 +25,8 @@ RUN set -eux; \
 	apt-get dist-clean
 
 ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
-ENV PYTHON_VERSION 3.10.18
-ENV PYTHON_SHA256 ae665bc678abd9ab6a6e1573d2481625a53719bc517e9a634ed2b9fefae3817f
+ENV PYTHON_VERSION 3.10.19
+ENV PYTHON_SHA256 c8f4a596572201d81dd7df91f70e177e19a70f1d489968b54b5fbbf29a97c076
 
 RUN set -eux; \
 	\
@@ -129,7 +129,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==79.0.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.10/trixie/Dockerfile
+++ b/3.10/trixie/Dockerfile
@@ -25,8 +25,8 @@ RUN set -eux; \
 	apt-get dist-clean
 
 ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
-ENV PYTHON_VERSION 3.10.18
-ENV PYTHON_SHA256 ae665bc678abd9ab6a6e1573d2481625a53719bc517e9a634ed2b9fefae3817f
+ENV PYTHON_VERSION 3.10.19
+ENV PYTHON_SHA256 c8f4a596572201d81dd7df91f70e177e19a70f1d489968b54b5fbbf29a97c076
 
 RUN set -eux; \
 	\
@@ -95,7 +95,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==79.0.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.11/alpine3.21/Dockerfile
+++ b/3.11/alpine3.21/Dockerfile
@@ -22,8 +22,8 @@ RUN set -eux; \
 	;
 
 ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
-ENV PYTHON_VERSION 3.11.13
-ENV PYTHON_SHA256 8fb5f9fbc7609fa822cb31549884575db7fd9657cbffb89510b5d7975963a83a
+ENV PYTHON_VERSION 3.11.14
+ENV PYTHON_SHA256 8d3ed8ec5c88c1c95f5e558612a725450d2452813ddad5e58fdb1a53b1209b78
 
 RUN set -eux; \
 	\
@@ -122,7 +122,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==79.0.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.11/alpine3.22/Dockerfile
+++ b/3.11/alpine3.22/Dockerfile
@@ -22,8 +22,8 @@ RUN set -eux; \
 	;
 
 ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
-ENV PYTHON_VERSION 3.11.13
-ENV PYTHON_SHA256 8fb5f9fbc7609fa822cb31549884575db7fd9657cbffb89510b5d7975963a83a
+ENV PYTHON_VERSION 3.11.14
+ENV PYTHON_SHA256 8d3ed8ec5c88c1c95f5e558612a725450d2452813ddad5e58fdb1a53b1209b78
 
 RUN set -eux; \
 	\
@@ -122,7 +122,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==79.0.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.11/bookworm/Dockerfile
+++ b/3.11/bookworm/Dockerfile
@@ -25,8 +25,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
-ENV PYTHON_VERSION 3.11.13
-ENV PYTHON_SHA256 8fb5f9fbc7609fa822cb31549884575db7fd9657cbffb89510b5d7975963a83a
+ENV PYTHON_VERSION 3.11.14
+ENV PYTHON_SHA256 8d3ed8ec5c88c1c95f5e558612a725450d2452813ddad5e58fdb1a53b1209b78
 
 RUN set -eux; \
 	\
@@ -95,7 +95,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==79.0.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.11/slim-bookworm/Dockerfile
+++ b/3.11/slim-bookworm/Dockerfile
@@ -25,8 +25,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
-ENV PYTHON_VERSION 3.11.13
-ENV PYTHON_SHA256 8fb5f9fbc7609fa822cb31549884575db7fd9657cbffb89510b5d7975963a83a
+ENV PYTHON_VERSION 3.11.14
+ENV PYTHON_SHA256 8d3ed8ec5c88c1c95f5e558612a725450d2452813ddad5e58fdb1a53b1209b78
 
 RUN set -eux; \
 	\
@@ -129,7 +129,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==79.0.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.11/slim-trixie/Dockerfile
+++ b/3.11/slim-trixie/Dockerfile
@@ -25,8 +25,8 @@ RUN set -eux; \
 	apt-get dist-clean
 
 ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
-ENV PYTHON_VERSION 3.11.13
-ENV PYTHON_SHA256 8fb5f9fbc7609fa822cb31549884575db7fd9657cbffb89510b5d7975963a83a
+ENV PYTHON_VERSION 3.11.14
+ENV PYTHON_SHA256 8d3ed8ec5c88c1c95f5e558612a725450d2452813ddad5e58fdb1a53b1209b78
 
 RUN set -eux; \
 	\
@@ -129,7 +129,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==79.0.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/3.11/trixie/Dockerfile
+++ b/3.11/trixie/Dockerfile
@@ -25,8 +25,8 @@ RUN set -eux; \
 	apt-get dist-clean
 
 ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
-ENV PYTHON_VERSION 3.11.13
-ENV PYTHON_SHA256 8fb5f9fbc7609fa822cb31549884575db7fd9657cbffb89510b5d7975963a83a
+ENV PYTHON_VERSION 3.11.14
+ENV PYTHON_SHA256 8d3ed8ec5c88c1c95f5e558612a725450d2452813ddad5e58fdb1a53b1209b78
 
 RUN set -eux; \
 	\
@@ -95,7 +95,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
-		'setuptools==65.5.1' \
+		'setuptools==79.0.1' \
 		# https://github.com/docker-library/python/issues/1023
 		'wheel<0.46' \
 	; \

--- a/versions.json
+++ b/versions.json
@@ -2,11 +2,11 @@
   "3.10": {
     "checksums": {
       "source": {
-        "sha256": "ae665bc678abd9ab6a6e1573d2481625a53719bc517e9a634ed2b9fefae3817f"
+        "sha256": "c8f4a596572201d81dd7df91f70e177e19a70f1d489968b54b5fbbf29a97c076"
       }
     },
     "setuptools": {
-      "version": "65.5.1"
+      "version": "79.0.1"
     },
     "variants": [
       "trixie",
@@ -16,16 +16,16 @@
       "alpine3.22",
       "alpine3.21"
     ],
-    "version": "3.10.18"
+    "version": "3.10.19"
   },
   "3.11": {
     "checksums": {
       "source": {
-        "sha256": "8fb5f9fbc7609fa822cb31549884575db7fd9657cbffb89510b5d7975963a83a"
+        "sha256": "8d3ed8ec5c88c1c95f5e558612a725450d2452813ddad5e58fdb1a53b1209b78"
       }
     },
     "setuptools": {
-      "version": "65.5.1"
+      "version": "79.0.1"
     },
     "variants": [
       "trixie",
@@ -35,7 +35,7 @@
       "alpine3.22",
       "alpine3.21"
     ],
-    "version": "3.11.13"
+    "version": "3.11.14"
   },
   "3.12": {
     "checksums": {

--- a/versions.sh
+++ b/versions.sh
@@ -171,11 +171,6 @@ for version in "${versions[@]}"; do
 				echo >&2 "error: $version: setuptools version ($setuptoolsVersion) seems to be invalid?"
 				exit 1
 			fi
-
-			# https://github.com/docker-library/python/issues/781 (TODO remove this if 3.10 and 3.11 embed a newer setuptools and this section no longer applies)
-			if [ "$setuptoolsVersion" = '65.5.0' ]; then
-				setuptoolsVersion='65.5.1'
-			fi
 			;;
 
 		*)


### PR DESCRIPTION
Racing `update.sh` job to bump these versions

Also drop the now unneeded part of versions.sh since `3.9`, `3.10`, and `3.11` have newer bundled `setuptools`.