### PR TITLE
Pinning wheel at version 0.46.3

### DIFF
--- a/3.10/alpine3.23/Dockerfile
+++ b/3.10/alpine3.23/Dockerfile
@@ -123,8 +123,7 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		'setuptools==79.0.1' \
-		# https://github.com/docker-library/python/issues/1023
-		'wheel<0.46' \
+		'wheel==0.46.3' \
 	; \
 	pip3 --version
 

--- a/3.10/alpine3.24/Dockerfile
+++ b/3.10/alpine3.24/Dockerfile
@@ -123,8 +123,7 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		'setuptools==79.0.1' \
-		# https://github.com/docker-library/python/issues/1023
-		'wheel<0.46' \
+		'wheel==0.46.3' \
 	; \
 	pip3 --version
 

--- a/3.10/bookworm/Dockerfile
+++ b/3.10/bookworm/Dockerfile
@@ -96,8 +96,7 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		'setuptools==79.0.1' \
-		# https://github.com/docker-library/python/issues/1023
-		'wheel<0.46' \
+		'wheel==0.46.3' \
 	; \
 	pip3 --version
 

--- a/3.10/slim-bookworm/Dockerfile
+++ b/3.10/slim-bookworm/Dockerfile
@@ -130,8 +130,7 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		'setuptools==79.0.1' \
-		# https://github.com/docker-library/python/issues/1023
-		'wheel<0.46' \
+		'wheel==0.46.3' \
 	; \
 	pip3 --version
 

--- a/3.10/slim-trixie/Dockerfile
+++ b/3.10/slim-trixie/Dockerfile
@@ -130,8 +130,7 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		'setuptools==79.0.1' \
-		# https://github.com/docker-library/python/issues/1023
-		'wheel<0.46' \
+		'wheel==0.46.3' \
 	; \
 	pip3 --version
 

--- a/3.10/trixie/Dockerfile
+++ b/3.10/trixie/Dockerfile
@@ -96,8 +96,7 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		'setuptools==79.0.1' \
-		# https://github.com/docker-library/python/issues/1023
-		'wheel<0.46' \
+		'wheel==0.46.3' \
 	; \
 	pip3 --version
 

--- a/3.11/alpine3.23/Dockerfile
+++ b/3.11/alpine3.23/Dockerfile
@@ -123,8 +123,7 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		'setuptools==79.0.1' \
-		# https://github.com/docker-library/python/issues/1023
-		'wheel<0.46' \
+		'wheel==0.46.3' \
 	; \
 	pip3 --version
 

--- a/3.11/alpine3.24/Dockerfile
+++ b/3.11/alpine3.24/Dockerfile
@@ -123,8 +123,7 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		'setuptools==79.0.1' \
-		# https://github.com/docker-library/python/issues/1023
-		'wheel<0.46' \
+		'wheel==0.46.3' \
 	; \
 	pip3 --version
 

--- a/3.11/bookworm/Dockerfile
+++ b/3.11/bookworm/Dockerfile
@@ -96,8 +96,7 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		'setuptools==79.0.1' \
-		# https://github.com/docker-library/python/issues/1023
-		'wheel<0.46' \
+		'wheel==0.46.3' \
 	; \
 	pip3 --version
 

--- a/3.11/slim-bookworm/Dockerfile
+++ b/3.11/slim-bookworm/Dockerfile
@@ -130,8 +130,7 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		'setuptools==79.0.1' \
-		# https://github.com/docker-library/python/issues/1023
-		'wheel<0.46' \
+		'wheel==0.46.3' \
 	; \
 	pip3 --version
 

--- a/3.11/slim-trixie/Dockerfile
+++ b/3.11/slim-trixie/Dockerfile
@@ -130,8 +130,7 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		'setuptools==79.0.1' \
-		# https://github.com/docker-library/python/issues/1023
-		'wheel<0.46' \
+		'wheel==0.46.3' \
 	; \
 	pip3 --version
 

--- a/3.11/trixie/Dockerfile
+++ b/3.11/trixie/Dockerfile
@@ -96,8 +96,7 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		'setuptools==79.0.1' \
-		# https://github.com/docker-library/python/issues/1023
-		'wheel<0.46' \
+		'wheel==0.46.3' \
 	; \
 	pip3 --version
 

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -323,8 +323,7 @@ RUN set -eux; \
 		--no-cache-dir \
 		--no-compile \
 		{{ "setuptools==\( .setuptools.version )" | @sh }} \
-		# https://github.com/docker-library/python/issues/1023
-		'wheel<0.46' \
+		'wheel==0.46.3' \
 	; \
 {{ ) else "" end -}}
 	pip3 --version


### PR DESCRIPTION
wheel <= 0.46.1 currently has a high severity CVE, and the version pinned in this repo is affected. The pin was originally due to wheel 0.46.0 removing `bdist_wheel`, but it was [later re-added in 0.46.2](https://wheel.readthedocs.io/en/stable/news.html), with a related fix in 0.46.3. Would it be possible to pin at 0.46.3 now, since the version fixes the CVE and won't break earlier versions of setuptools?


Related issues:
[CVE-2026-24049 for wheel <=0.46.1](https://github.com/docker-library/python/issues/1112)
[wheel 0.46.0 release had breaking changes](https://github.com/docker-library/python/issues/1023)