### PR TITLE
Ditch architectures that are failing to build 3.15+ on Alpine

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -139,6 +139,23 @@ for version; do
 		# https://github.com/python/cpython/issues/93619 (Linking error when building 3.11 beta on mips64le) + https://peps.python.org/pep-0011/ (mips is not even tier 3)
 		variantArches="$(sed <<<" $variantArches " -e 's/ mips64le / /g')"
 
+		if [[ "$variant" == alpine* ]]; then
+			# https://github.com/python/cpython/issues/143632
+			# /usr/include/sys/prctl.h:88:8: error: redefinition of 'struct prctl_mm_map'
+			case "$version" in
+				3.10 | 3.11 | 3.12 | 3.13 | 3.14) ;;
+				*)
+					variantArches="$(
+						sed <<<" $variantArches " \
+							-e 's/ arm32v6 / /g' \
+							-e 's/ arm32v7 / /g' \
+							-e 's/ i386 / /g' \
+							-e 's/ ppc64le / /g' \
+					)"
+					;;
+			esac
+		fi
+
 		sharedTags=()
 		for windowsShared in windowsservercore nanoserver; do
 			if [[ "$variant" == "$windowsShared"* ]]; then


### PR DESCRIPTION
- refs https://github.com/python/cpython/issues/143632

```diff
$ diff -u --color <(bashbrew cat python) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63	2026-07-10 10:52:06.555577857 -0700
+++ /dev/fd/62	2026-07-10 10:52:06.555577857 -0700
@@ -24,12 +24,12 @@
 Directory: 3.15-rc/slim-bookworm
 
 Tags: 3.15.0b3-alpine3.24, 3.15-rc-alpine3.24, 3.15.0b3-alpine, 3.15-rc-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+Architectures: amd64, arm64v8, riscv64, s390x
 GitCommit: 4f07059567fa61c80397126e8063dbbde011b794
 Directory: 3.15-rc/alpine3.24
 
 Tags: 3.15.0b3-alpine3.23, 3.15-rc-alpine3.23
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+Architectures: amd64, arm64v8, riscv64, s390x
 GitCommit: 4f07059567fa61c80397126e8063dbbde011b794
 Directory: 3.15-rc/alpine3.23
 
```