### PR TITLE
Remove mips64le special case

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -136,9 +136,6 @@ for version; do
 				;;
 		esac
 
-		# https://github.com/python/cpython/issues/93619 (Linking error when building 3.11 beta on mips64le) + https://peps.python.org/pep-0011/ (mips is not even tier 3)
-		variantArches="$(sed <<<" $variantArches " -e 's/ mips64le / /g')"
-
 		sharedTags=()
 		for windowsShared in windowsservercore nanoserver; do
 			if [[ "$variant" == "$windowsShared"* ]]; then


### PR DESCRIPTION
This architecture is no longer supported by the base images (or the DOI program; https://github.com/docker-library/official-images/pull/21977).