### PR TITLE
Add g++ to fix extension builds

### DIFF
--- a/3.10/alpine3.23/Dockerfile
+++ b/3.10/alpine3.23/Dockerfile
@@ -32,6 +32,7 @@ RUN set -eux; \
 		bzip2-dev \
 		dpkg-dev dpkg \
 		findutils \
+		g++ \
 		gcc \
 		gdbm-dev \
 		gnupg \

--- a/3.10/alpine3.24/Dockerfile
+++ b/3.10/alpine3.24/Dockerfile
@@ -32,6 +32,7 @@ RUN set -eux; \
 		bzip2-dev \
 		dpkg-dev dpkg \
 		findutils \
+		g++ \
 		gcc \
 		gdbm-dev \
 		gnupg \

--- a/3.10/slim-bookworm/Dockerfile
+++ b/3.10/slim-bookworm/Dockerfile
@@ -34,6 +34,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		dpkg-dev \
+		g++ \
 		gcc \
 		gnupg \
 		libbluetooth-dev \

--- a/3.10/slim-trixie/Dockerfile
+++ b/3.10/slim-trixie/Dockerfile
@@ -34,6 +34,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		dpkg-dev \
+		g++ \
 		gcc \
 		gnupg \
 		libbluetooth-dev \

--- a/3.11/alpine3.23/Dockerfile
+++ b/3.11/alpine3.23/Dockerfile
@@ -32,6 +32,7 @@ RUN set -eux; \
 		bzip2-dev \
 		dpkg-dev dpkg \
 		findutils \
+		g++ \
 		gcc \
 		gdbm-dev \
 		gnupg \

--- a/3.11/alpine3.24/Dockerfile
+++ b/3.11/alpine3.24/Dockerfile
@@ -32,6 +32,7 @@ RUN set -eux; \
 		bzip2-dev \
 		dpkg-dev dpkg \
 		findutils \
+		g++ \
 		gcc \
 		gdbm-dev \
 		gnupg \

--- a/3.11/slim-bookworm/Dockerfile
+++ b/3.11/slim-bookworm/Dockerfile
@@ -34,6 +34,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		dpkg-dev \
+		g++ \
 		gcc \
 		gnupg \
 		libbluetooth-dev \

--- a/3.11/slim-trixie/Dockerfile
+++ b/3.11/slim-trixie/Dockerfile
@@ -34,6 +34,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		dpkg-dev \
+		g++ \
 		gcc \
 		gnupg \
 		libbluetooth-dev \

--- a/3.12/alpine3.23/Dockerfile
+++ b/3.12/alpine3.23/Dockerfile
@@ -32,6 +32,7 @@ RUN set -eux; \
 		bzip2-dev \
 		dpkg-dev dpkg \
 		findutils \
+		g++ \
 		gcc \
 		gdbm-dev \
 		gnupg \

--- a/3.12/alpine3.24/Dockerfile
+++ b/3.12/alpine3.24/Dockerfile
@@ -32,6 +32,7 @@ RUN set -eux; \
 		bzip2-dev \
 		dpkg-dev dpkg \
 		findutils \
+		g++ \
 		gcc \
 		gdbm-dev \
 		gnupg \

--- a/3.12/slim-bookworm/Dockerfile
+++ b/3.12/slim-bookworm/Dockerfile
@@ -34,6 +34,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		dpkg-dev \
+		g++ \
 		gcc \
 		gnupg \
 		libbluetooth-dev \

--- a/3.12/slim-trixie/Dockerfile
+++ b/3.12/slim-trixie/Dockerfile
@@ -34,6 +34,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		dpkg-dev \
+		g++ \
 		gcc \
 		gnupg \
 		libbluetooth-dev \

--- a/3.13/alpine3.23/Dockerfile
+++ b/3.13/alpine3.23/Dockerfile
@@ -27,6 +27,7 @@ RUN set -eux; \
 		bzip2-dev \
 		dpkg-dev dpkg \
 		findutils \
+		g++ \
 		gcc \
 		gdbm-dev \
 		gnupg \

--- a/3.13/alpine3.24/Dockerfile
+++ b/3.13/alpine3.24/Dockerfile
@@ -27,6 +27,7 @@ RUN set -eux; \
 		bzip2-dev \
 		dpkg-dev dpkg \
 		findutils \
+		g++ \
 		gcc \
 		gdbm-dev \
 		gnupg \

--- a/3.13/slim-bookworm/Dockerfile
+++ b/3.13/slim-bookworm/Dockerfile
@@ -29,6 +29,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		dpkg-dev \
+		g++ \
 		gcc \
 		gnupg \
 		libbluetooth-dev \

--- a/3.13/slim-trixie/Dockerfile
+++ b/3.13/slim-trixie/Dockerfile
@@ -29,6 +29,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		dpkg-dev \
+		g++ \
 		gcc \
 		gnupg \
 		libbluetooth-dev \

--- a/3.14/alpine3.23/Dockerfile
+++ b/3.14/alpine3.23/Dockerfile
@@ -26,6 +26,7 @@ RUN set -eux; \
 		bzip2-dev \
 		dpkg-dev dpkg \
 		findutils \
+		g++ \
 		gcc \
 		gdbm-dev \
 		gnupg \

--- a/3.14/alpine3.24/Dockerfile
+++ b/3.14/alpine3.24/Dockerfile
@@ -26,6 +26,7 @@ RUN set -eux; \
 		bzip2-dev \
 		dpkg-dev dpkg \
 		findutils \
+		g++ \
 		gcc \
 		gdbm-dev \
 		gnupg \

--- a/3.14/slim-bookworm/Dockerfile
+++ b/3.14/slim-bookworm/Dockerfile
@@ -28,6 +28,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		dpkg-dev \
+		g++ \
 		gcc \
 		gnupg \
 		libbluetooth-dev \

--- a/3.14/slim-trixie/Dockerfile
+++ b/3.14/slim-trixie/Dockerfile
@@ -28,6 +28,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		dpkg-dev \
+		g++ \
 		gcc \
 		gnupg \
 		libbluetooth-dev \

--- a/3.15-rc/alpine3.23/Dockerfile
+++ b/3.15-rc/alpine3.23/Dockerfile
@@ -26,6 +26,7 @@ RUN set -eux; \
 		bzip2-dev \
 		dpkg-dev dpkg \
 		findutils \
+		g++ \
 		gcc \
 		gdbm-dev \
 		gnupg \

--- a/3.15-rc/alpine3.24/Dockerfile
+++ b/3.15-rc/alpine3.24/Dockerfile
@@ -26,6 +26,7 @@ RUN set -eux; \
 		bzip2-dev \
 		dpkg-dev dpkg \
 		findutils \
+		g++ \
 		gcc \
 		gdbm-dev \
 		gnupg \

--- a/3.15-rc/slim-bookworm/Dockerfile
+++ b/3.15-rc/slim-bookworm/Dockerfile
@@ -28,6 +28,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		dpkg-dev \
+		g++ \
 		gcc \
 		gnupg \
 		libbluetooth-dev \

--- a/3.15-rc/slim-trixie/Dockerfile
+++ b/3.15-rc/slim-trixie/Dockerfile
@@ -28,6 +28,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		dpkg-dev \
+		g++ \
 		gcc \
 		gnupg \
 		libbluetooth-dev \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -98,6 +98,7 @@ RUN set -eux; \
 		"bzip2-dev",
 		"dpkg-dev dpkg",
 		"findutils",
+		"g++",
 		"gcc",
 		"gdbm-dev",
 		"gnupg",
@@ -127,6 +128,7 @@ RUN set -eux; \
 	else
 		if is_slim then
 			"dpkg-dev",
+			"g++",
 			"gcc",
 			"gnupg",
 			"libbluetooth-dev",


### PR DESCRIPTION
Fixes https://github.com/docker-library/python/issues/1131

While the upstream fix was not backported to 3.13 and earlier, it should be harmless to install and remove `g++`.

Refs:
- https://github.com/python/cpython/pull/148298
- https://github.com/python/cpython/pull/150211
- https://github.com/python/cpython/pull/150212